### PR TITLE
bug: ajout de data-pagefind-ignore sur la page search-results #124

### DIFF
--- a/content/fr/search-results.njk
+++ b/content/fr/search-results.njk
@@ -3,7 +3,7 @@ title: Résultats de la recherche
 layout: layouts/base.njk
 ---
 
-<div class="fr-container fr-my-6w">
+<div class="fr-container fr-my-6w" data-pagefind-ignore>
     <div class="fr-grid-row">
         <div class="fr-col-12">
             <div class="fr-mb-6w">


### PR DESCRIPTION
Evite que la page des résultats de recherche _vide_ soit référencée dans les résultats de recherche

Voir #124 