### PR TITLE
fix: comportement du sidemenu en version mobile

### DIFF
--- a/_includes/templates/sidemenu.njk
+++ b/_includes/templates/sidemenu.njk
@@ -72,6 +72,9 @@
         function expandParents(element) {
             let parent = element.closest(".fr-collapse");
             while (parent) {
+                if (parent.id === "fr-sidemenu-wrapper") {
+                    break;
+                }
                 const toggleButton = parent.previousElementSibling;
                 if (toggleButton?.classList.contains("fr-sidemenu__btn")) {
                     toggleButton.setAttribute("aria-expanded", "true");


### PR DESCRIPTION
Correction du comportement du sidemenu en version mobile. Le bouton "Dans cette rubrique" ne se repliais pas après avoir cliqué sur une page du menu, c'est maintenant le cas (comportement similaire à celui du site du DSFR).