### PR TITLE
feat: supprime les tags des gabarits (#145)

### DIFF
--- a/_includes/layouts/article.njk
+++ b/_includes/layouts/article.njk
@@ -31,7 +31,6 @@ layout: layouts/base.njk
             {% include "components/breadcrumb.njk" %}
           {% endif %}
           <h1>{{ title }}</h1>
-          {% include "components/taggroup-disabled.njk" %}
           {% include "components/published_on.njk" %}
           {% if description %}
             <p class="fr-text--lead">{{ description }}</p>

--- a/_includes/layouts/page.njk
+++ b/_includes/layouts/page.njk
@@ -12,7 +12,6 @@ layout: layouts/base.njk
                         {% include "components/breadcrumb.njk" %}
                     {% endif %}
                     <h1>{{ title }}</h1>
-                    {% include "components/taggroup-disabled.njk" %}
                     {% include "components/published_on.njk" %}
 
                     {% if description %}<p class="fr-text--lead">{{ description }}</p>{% endif %}

--- a/_includes/layouts/parent.njk
+++ b/_includes/layouts/parent.njk
@@ -36,7 +36,6 @@ layout: layouts/base.njk
             {% include "components/breadcrumb.njk" %}
           {% endif %}
           <h1>{{ title }}</h1>
-          {% include "components/taggroup-disabled.njk" %}
           {% include "components/published_on.njk" %}
           {% if description %}
             <p class="fr-text--lead">{{ description }}</p>


### PR DESCRIPTION
Les tags ne sont plus visibles sur les pages de contenu mais restent disponibles comme filtres dans les résultats de recherche.

Issue #145 