### PR TITLE
feat: modifie le title des pages et flux (ref #162)

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -70,7 +70,7 @@
     <script src="/js/swagger-ui.js"></script>
 {% endif %}
 <script src="/js/copy.js" defer></script>
-<title>{{ title or metadata.title }}</title>
+<title>{{ title  ~ " | " ~ metadata.description ~ " | " ~ metadata.title }}</title>
 </head>
 <body id="top">
     {% getBundle "js", "top" %}

--- a/content/feed/feed.njk
+++ b/content/feed/feed.njk
@@ -5,7 +5,7 @@ numberOfLatestPostsToShow: 10
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ metadata.language }}">
-<title>{{ metadata.title }}</title>
+<title>{{ metadata.description ~ " | " ~ metadata.title }}</title>
 <subtitle>{{ metadata.description }}</subtitle>
 <link href="{{ permalink | htmlBaseUrl(metadata.url) }}" rel="self" />
 <link href="{{ metadata.url | addPathPrefixToFullUrl }}" />

--- a/content/feed/json.njk
+++ b/content/feed/json.njk
@@ -6,7 +6,7 @@ numberOfLatestPostsToShow: 10
 
 {
 "version": "https://jsonfeed.org/version/1.1",
-"title": "{{ metadata.title }}",
+"title": "{{ metadata.description ~ " | " ~ metadata.title }}",
 "language": "{{ metadata.language }}",
 "home_page_url": "{{ metadata.site_url | addPathPrefixToFullUrl }}",
 "feed_url": "{{ permalink | htmlBaseUrl(metadata.url) }}",


### PR DESCRIPTION
Modifie le titre des pages en "Titre de la page | Documentation | cartes.gouv.fr"

_cartes.gouv.fr_ étant le titre du site et _Documentation_ sa description ou tagline (2ème ligne du header).

<img width="349" height="63" alt="image" src="https://github.com/user-attachments/assets/e0df658e-74bc-427c-a959-5114ca227e6e" />


Pour une meilleure référence dans les agrégateurs de flux, la description est également ajoutée au titre des flux RSS.

Issue concernée : #162 

@cbrousseau1 si c'est ok pour toi tu peux merger dans la foulée

