### PR TITLE
Composant sommaire

### DIFF
--- a/_includes/components/summary.njk
+++ b/_includes/components/summary.njk
@@ -1,0 +1,20 @@
+
+{% macro itemList(subItems) %}
+    {% for item in subItems %}
+        <li>
+            <a class="fr-summary__link" id="summary-link-{{ item.id }}" href="#{{ item.id }}">{{ item.name }}</a>
+            {% if item.children.length > 0 %}
+                <ol>
+                    {{ itemList(item.children) }}
+                </ol>
+            {% endif %}
+        </li>
+    {% endfor %}
+{% endmacro %}
+
+<nav class="fr-summary" role="navigation" aria-labelledby="fr-summary-title">
+    <h2 class="fr-summary__title" id="fr-summary-title">Sommaire</h2>
+    <ol>
+        {{ itemList(summaryItems) }}
+    </ol>
+</nav>

--- a/_includes/components/summary.njk
+++ b/_includes/components/summary.njk
@@ -12,7 +12,7 @@
     {% endfor %}
 {% endmacro %}
 
-<nav class="fr-summary" role="navigation" aria-labelledby="fr-summary-title">
+<nav class="fr-summary fr-mb-6w" role="navigation" aria-labelledby="fr-summary-title">
     <h2 class="fr-summary__title" id="fr-summary-title">Sommaire</h2>
     <ol>
         {{ itemList(summaryItems) }}

--- a/_includes/layouts/article.njk
+++ b/_includes/layouts/article.njk
@@ -27,6 +27,11 @@ layout: layouts/base.njk
           {% if showBreadcrumb %}
             {% include "components/breadcrumb.njk" %}
           {% endif %}
+          {% if summary.visible %}
+            {% set depth = summary.depth | default(1) %}
+            {% set summaryItems = content | getSummaryItems(depth) %}
+            {% include "components/summary.njk" %}
+          {% endif %}
           <h1>{{ title }}</h1>
           {% include "components/published_on.njk" %}
           {% if description %}

--- a/content/fr/fr.11tydata.js
+++ b/content/fr/fr.11tydata.js
@@ -20,4 +20,7 @@ module.exports = {
     },
     showBreadcrumb: true,
     date: "git Last Modified",
+    summary: {
+        visible: false,
+    },
 };

--- a/content/fr/guides-producteur/creer-des-pages-de-documentation/bonnes-pratiques-redactionnelles.md
+++ b/content/fr/guides-producteur/creer-des-pages-de-documentation/bonnes-pratiques-redactionnelles.md
@@ -10,6 +10,9 @@ eleventyNavigation:
     order: 4
     nav: guides-producteur
 pictogram: document/contract.svg
+summary:
+    visible: true
+    depth: 2
 ---
 
 {% from "components/component.njk" import component with context %}
@@ -20,9 +23,9 @@ Cette page répertorie les bonnes pratiques d’écriture à appliquer à votre 
 Avant de commencer vos modifications, pensez à effectuer les étapes préalables indiquées précédemment. Vous éviterez ainsi d’éventuels conflits.
 :::
 
-## 1 - Bonnes pratiques rédactionnelles générales
+## Bonnes pratiques rédactionnelles générales
 
-### 1.1 - Abréviations
+### Abréviations
 
 Sauf exception, les abréviations sont interdites. Écrivez en toutes lettres :
 
@@ -34,11 +37,11 @@ _cf., etc., HT, NB, n°,_ les unités de mesure, de longueur et de temps (_20 k
 
 En cas de doute, préférez toujours la version non-abrégée.
 
-### 1.2 - Emojis
+### Emojis
 
 N’utilisez pas d’emojis.
 
-### 1.3 - Anglicisme
+### Anglicisme
 
 Les anglicismes sont interdits quand un équivalent existe en français courant.
 
@@ -57,29 +60,29 @@ Les anglicismes sont interdits quand un équivalent existe en français couran
     ]
 }) }}
 
-### 1.4 - Conjonction de coordination
+### Conjonction de coordination
 
 _Mais, ou, et, donc, or, ni, car_
 
 Limitez autant que possible leur utilisation à une seule conjonction de coordination par phrase.
 
-### 1.5 - Dates et horaires
+### Dates et horaires
 
 Pour les dates : utilisez les chiffres, à part pour les mois qu’il faut écrire en toutes lettres et sans majuscule (_28 novembre 2019_).
 
 Pour les horaires : utilisez seulement les chiffres et abrégez « heures » en « h » (_20h00_).
 
-### 1.6 - Figures de styles
+### Figures de styles
 
 Évitez le recours abusif aux figures de style (en particulier les métaphores) qui nuisent à la fluidité et la lisibilité de l’information
 
-### 1.7 - « Français » ou « français »
+### « Français » ou « français »
 
 En général, les noms de peuples ou d’habitants prennent toujours une majuscule : les Français, les Parisiens, les Bretons.
 
 Dans tous les autres cas, on écrit « français » sans majuscule (_Les Français parlent le français._).
 
-### 1.8 - Majuscules, fonctions et Ministères
+### Majuscules, fonctions et Ministères
 
 - Les institutions prennent une majuscule (_le Gouvernement, le ministère des Armées, le Sénat, l’Assemblée nationale_).
 - Les fonctions et titres sont toujours en minuscules (_Le préfet de Police de Paris a fait une déclaration à la presse_).
@@ -104,26 +107,26 @@ Les raccourcis clavier pour les majuscules avec accent et le Ç majuscule sont l
 
 Sauf exception, n’écrivez jamais un texte tout en majuscules. Pour mettre en valeur un titre ou un paragraphe par rapport au reste d’un texte, augmentez la taille de la police et/ou graissez la typographie. Dans certains cas seulement, vous pouvez souligner.
 
-### 1.9 - Négations
+### Négations
 
 En français, les négations se construisent avec l’adverbe « ne pas ». N’utilisez pas de demi-négation (_Le salarié ne peut refuser sa formation._) et ne multipliez pas les négations (_L’adoption n’est pas possible pour les couples non mariés_).
 
 Par ailleurs, quand c’est possible, exprimez les négations par la forme affirmative : préférez « Il est encore temps pour... » à « Il n’est pas trop tard pour... ».
 
-### 1.10 - Nombres
+### Nombres
 
 En communication écrite, écrivez les chiffres (de un à neuf) en toutes lettres et les nombres avec des chiffres (_18 ans, 20 000 participants_).
 
 Toutefois, « millions » et « milliards » s’écrivent en toutes lettres (_66,9 millions de Français, 70 milliards d’euros_).
 
-### 1.11 - Ponctuation
+### Ponctuation
 
 - À utiliser sans réserve : le point. Plus vous l’utilisez, plus vos phrases sont courtes.
 - À utiliser raisonnablement : la virgule. Évitez les phrases trop longues, en apposition, ou les constructions complexes.
 - À utiliser rarement : les points de suspension et le point d’exclamation. Ces signes apportent une emphase ou un suspense qui sont rarement utiles ou souhaitables.
 - À ne pas utiliser : le point-virgule. Son usage est de moins en moins courant et peut avoir une connotation pompeuse.
 
-### 1.12 - Sigles et acronymes
+### Sigles et acronymes
 
 Les sigles sont des ensembles de lettres initiales prononcées une à une pour former un mot (_FMI, LGBT, TGV, TVA_). Les acronymes sont des sigles particuliers qui se prononcent comme des mots (_ASSEDIC, DOM-TOM, HADOPI, MEDEF, INSEE, URSSAF, ZEP_).
 
@@ -133,11 +136,11 @@ Dans le cas contraire, précisez les mots qui composent le sigle ou l’acronym
 
 En cas de doute, partez du principe que le citoyen ne connaît pas la signification du sigle.
 
-### 1.13 - Sources
+### Sources
 
 Pour garantir une information fiable et objective aux citoyens, il est indispensable de toujours citer la source d’une information. Celle-ci sera indiquée entre parenthèses : « (Source : XX) ».
 
-### 1.14 - Langues
+### Langues
 
 Lorsqu’on cite un texte en langue étrangère dans une page dont la langue principale renseignée est le français, il faut indiquer le changement de langue sur chaque élément de la page concerné via l’attribut html lang. Afin de mettre le mot en exergue, ajoutez également des _<html lang="en">underscores</html>_ pour mettre le mot en italique.
 
@@ -149,7 +152,7 @@ Lorsqu’on cite un texte en langue étrangère dans une page dont la langue pri
 _. {% endraw %}
 ```
 
-### 1.15 - Liens url
+### Liens url
 
 Rendez les liens url explicites à la lecture. Ci-dessous plusieurs exemples :
 
@@ -162,35 +165,45 @@ Rendez les liens url explicites à la lecture. Ci-dessous plusieurs exemples :
     ]
 }) }}
 
-## 2 - Recommandations pour cohérence d’ensemble du site Cartes.gouv.fr
+## Recommandations pour cohérence d’ensemble du site Cartes.gouv.fr
 
-### 2.1 - Apostrophes spéciaux
+### Apostrophes spéciaux
 
-Utilisez les apostrophes spéciaux : « ’ ». Raccourci clavier : _alt+0146_
+Utilisez les apostrophes spéciaux : « ’ ». Raccourci clavier : <kbd>alt+0146</kbd>
 
-### 2.2 - Espaces insécables
+### Espaces insécables
 
-Utilisez des espaces insécables aux endroits clefs (avant les : ! > « etc.). Raccourci clavier : _alt+0160_
+Utilisez des espaces insécables aux endroits ou vous ne souhaitez pas de passage à la ligne intempestifs sur certaines largeurs d’écran.
 
-### 2.3 - Guillemets
+Placez en notamment avant les signes de ponctuation double : ! « etc.
 
-Utilisez les guillemets français : « ». Raccourcis clavier : _alt+174_ et _alt+175_
+Raccourci clavier : <kbd>alt+0160</kbd>
 
-### 2.4 - Titres
+### Guillemets
 
-Numérotez les titres et ajoutez des « : » à la fin du titre :
+Utilisez les guillemets français : « ». Raccourcis clavier : <kbd>alt+174</kbd> et <kbd>alt+175</kbd>
+
+Attention : le guillemet ouvrant doit être suivi d’un espace insécable et le guillemet fermant suivi d’un espace insécable.
+
+### Titres
+
+Précédez vos titres de 2 ou plusieurs « # ».
+
+Commencez par « ## » pour les titres de premier niveau car le # seul est réservé au titre de la page elle-même.
+
+Ne sautez pas de niveau hiérarchique.
 
 ```markdown
 {% raw %}
 
-## 1 - Mon titre de niveau 1
+## Mon titre de niveau 1
 
-### 1.1 - Mon titre de niveau 2
+### Mon titre de niveau 2
 
 {% endraw %}
 ```
 
-### 2.5 - Extraits de texte
+### Extraits de texte
 
 Indiquez les citations/extraits de site en **gras** et **entre guillemets français**. Exemple :
 
@@ -200,28 +213,32 @@ Cliquez sur **« Pyramides de tuiles raster »**
 {% endraw %}
 ```
 
-### 2.6 - Infinitif et impératif
+### Infinitif et impératif
 
 Privilégiez de conjuguer les verbes à la deuxième personne du pluriel plutôt que d’utiliser l’infinitif : « Pensez à bien séparer […] ».
 
-### 2.7 - Aération des pages
+### Aération des pages
 
 Ajoutez de l’aération à vos pages à l’aide de lignes séparatrices :
 
 ```markdown
 {% raw %}
-[...] et c’est ainsi que se termine le dernier paragraphe de la partie 1.1 de cette page.
+[…] et c’est ainsi que se termine le dernier paragraphe de la partie 1.1 de cette page.
 
-### 1.2 - Titre de la partie 1.2
+### Titre de la partie 1.2
 
 {% endraw %}
 ```
 
-### 2.8 - _Tags_
+### _Tags_
 
 Dans l’espace documentaire, écrivez les _tags_ en français, avec la première lettre en majuscule. Mettez les accents, les espaces et les apostrophes. Écrivez les _tags_ au singulier si possible. Exemple :
 
 « Partenaire », « Guyane », « WFS », « Modèle numérique de terrain », « RGE ALTI »
+
+Les _tags_ apparaissent dans les résultats de recherche et permettent de les filtrer. Vérifiez qu’il n’existe pas de variantes orthographiques d’un même tag
+
+----
 
 Vous savez maintenant tout ce qu’il faut savoir pour modifier votre documentation ! Rendez-vous page suivante pour connaitre la procédure pour faire valider ces modifications.
 

--- a/content/fr/guides-producteur/creer-des-pages-de-documentation/bonnes-pratiques-redactionnelles.md
+++ b/content/fr/guides-producteur/creer-des-pages-de-documentation/bonnes-pratiques-redactionnelles.md
@@ -173,9 +173,9 @@ Utilisez les apostrophes spéciaux : « ’ ». Raccourci clavier : <kbd>alt
 
 ### Espaces insécables
 
-Utilisez des espaces insécables aux endroits ou vous ne souhaitez pas de passage à la ligne intempestifs sur certaines largeurs d’écran.
+Utilisez des espaces insécables aux endroits où vous ne souhaitez pas de passage à la ligne intempestifs sur certaines largeurs d’écran.
 
-Placez en notamment avant les signes de ponctuation double : ! « etc.
+Placez-en notamment avant les signes de ponctuation double : ! « etc.
 
 Raccourci clavier : <kbd>alt+0160</kbd>
 

--- a/content/fr/guides-producteur/creer-des-pages-de-documentation/demander-pull-request.md
+++ b/content/fr/guides-producteur/creer-des-pages-de-documentation/demander-pull-request.md
@@ -11,6 +11,8 @@ eleventyNavigation:
     order: 5
     nav: guides-producteur
 pictogram: custom/document-upload.svg
+summary:
+    visible: true
 ---
 
 {% from "components/component.njk" import component with context %}
@@ -21,13 +23,13 @@ Cette page explique la procédure pour fusionner vos modifications faites en loc
 Avant de confirmer la fusion, vérifiez que le dépôt principal n’ait pas pris d’avance sur votre *fork* : voir [Étapes préalables aux modifications](./etapes-initiales-aux-modifications/).
 :::
 
-## 1 - Enregistrer
+## Enregistrer les modifications
 
 Pensez à bien enregistrer toutes vos modifications, sinon elles ne seront pas prises en compte dans la suite de la procédure. Dans _Visual Studio_ un petit rond apparait à côté du nom du fichier si celui-ci a été modifié et pas encore enregistré.
 
 ![Image décrivant un fichier non enregistré dans Visual Studio](/img/guides-producteur/creer-des-pages-de-documentation/demander-pull-request/01_Fichier-non-enregistre.png){.fr-responsive-img .frx-border-img .frx-img-contained}
 
-## 2 - Passer en revue les modifications
+## Passer en revue les modifications
 
 Gardez l’invite de commande _Git Bash_ utilisée pour faire tourner la prévisualisation avec _Eleventy_ ouvert à part. Ouvrez une nouvelle invite de commande _Git Bash_ à la racine du projet.
 
@@ -45,7 +47,7 @@ Les fichiers non-enregistrés peuvent ne pas apparaitre dans la liste des modifi
 
 ![Image décrivant le résultat de la commande git status](/img/guides-producteur/creer-des-pages-de-documentation/demander-pull-request/02_Git-status.png){.fr-responsive-img .frx-border-img .frx-img-contained}
 
-## 3 - Choisir les fichiers à fusionner
+## Choisir les fichiers à fusionner
 
 Vous pouvez soit ajouter toutes vos modifications avec la commande suivante :
 
@@ -59,7 +61,7 @@ Soit ajouter uniquement certains fichiers un à un avec la commande suivante :
 git add content/fr/partenaires/partenaireABC/.../monfichier.md
 ```
 
-## 4 - Pousser les modifications sur votre _fork_
+## Pousser les modifications sur votre _fork_
 
 Il faut maintenant transmettre vos modifications locales à votre _fork_ sur _github_. Pour cela lancez la commande suivante pour créer un nouveau paquet (_commit_) :
 
@@ -81,7 +83,7 @@ Vous pouvez voir sur le _github_ de votre _fork_ que celle-ci est à présent en
 
 ![Image décrivant l’avance du fork sur le dépôt princiapl](/img/guides-producteur/creer-des-pages-de-documentation/demander-pull-request/03_Avance-du-fork-sur-le-depot-principal.png){.fr-responsive-img .frx-border-img .frx-img-contained}
 
-## 5 - Demander une _pull request_
+## Demander une _pull request_
 
 La dernière étape consiste à demander au dépôt principal d’accepter vos modifications, il s’agit de la _pull request_ (ou de la demande de _merge_).
 
@@ -93,7 +95,7 @@ Ajoutez un titre et une description concise puis cliquez sur **« Create pull r
 
 Un autre membre du projet devra alors vérifier la demande et l’accepter. Dès que cela sera fait, les modifications apparaitront sur le site.
 
-## 6 - Supprimer la branche
+## Supprimer la branche
 
 Une fois que la _pull request_ a été acceptée, il faudra supprimer la branche.
 

--- a/content/fr/guides-producteur/creer-des-pages-de-documentation/etapes-prealables-aux-modifications.md
+++ b/content/fr/guides-producteur/creer-des-pages-de-documentation/etapes-prealables-aux-modifications.md
@@ -12,24 +12,26 @@ eleventyNavigation:
     order: 2
     nav: guides-producteur
 pictogram: digital/in-progress.svg
+summary:
+    visible: true
 ---
 
 {% from "components/component.njk" import component with context %}
 
 Cette page explique la procédure à suivre avant de faire toute modification de contenu.
 
-## 1 - Principe
+## Principe
 
 Afin de partir sur des bases saines il est conseillé de mettre à jour votre _fork_ (duplication github) et votre clone local afin qu’ils soient identiques au dépôt principal. Une fois cela fait, vous pourrez être sûr que les modifications que vous proposez ne viennent pas en conflit avec d’autres modifications récentes.
 
-## 2 - Mettre à jour votre _fork_
+## Mettre à jour votre _fork_
 
 Rendez-vous sur la page de votre _fork_. Github affiche au dessus de la liste des dossiers et fichiers l’état de synchronisation de votre _fork_ (commits en avance ou en retard)
 
 ![Image décrivant l’affichage du statut du fork sur github](/img/guides-producteur/creer-des-pages-de-documentation/etapes-prealables-aux-modifications/01_Statut-fork-sur-github.png){.fr-responsive-img .frx-border-img .frx-img-contained}
 Si votre _fork_ a du retard sur le dépôt principal, vous pouvez cliquer sur le bouton **« Sync *fork* »** directement pour le mettre à jour.
 
-## 3 - Créer une branche
+## Créer une branche
 
 Afin de permettre d’effectuer plusieurs modifications en parallèle et de facilliter la synchronisation, il est conseillé de travailler avec des _branches_. Par défaut votre _fork_/duplication contient une seule branche, la branche principale (_main_).
 
@@ -73,7 +75,7 @@ git branch -l
 
 ![Image décrivant le listing et le changement de branches dans l’invite de commande Git Bash](/img/guides-producteur/creer-des-pages-de-documentation/etapes-prealables-aux-modifications/03_Liste-des-branches.png){.fr-responsive-img .frx-border-img .frx-img-contained}
 
-## 4 - Mettre à jour votre clone local
+## Mettre à jour votre clone local
 
 Dans l’invite de commande _Git Bash_ lancez la commande suivante :
 
@@ -97,7 +99,7 @@ git stash apply
 Les commandes peuvent se lancer depuis n’importe quelle branche mais il est conseillé de se placer à la racine du projet.
 :::
 
-## 5 - Changer son pseudonyme sur _github_
+## Changer son pseudonyme sur _github_
 
 Par défaut _github_ génère votre pseudonyme à partir des informations de votre ordinateur. Pour modifier le pseudonyme et le courriel à utiliser (qui seront visibles par tous les contributeurs), lancez les commandes suivantes sur *Git Bash* :
 
@@ -106,7 +108,7 @@ git config --global user.name "MonPseudoGithub"
 git config --global user.email mail@domaine.fr
 ```
 
-## 6 - Exécuter _Eleventy_ pour construire le site
+## Exécuter _Eleventy_ pour construire le site
 
 Cette procédure permet de prévisualiser votre clone local et toutes les modifications que vous y apportez dans votre navigateur, avant d’en demander la fusion finale au dépôt principal. La prévisualisation est disponible sous l’adresse <a href="http://localhost:8080/fr" target="_blank" rel="noopener noreferrer" title="http://localhost:8080/fr - ouvre une nouvelle fenêtre">http://localhost:8080/fr</a>.
 

--- a/content/fr/guides-producteur/creer-des-pages-de-documentation/installation-documentation.md
+++ b/content/fr/guides-producteur/creer-des-pages-de-documentation/installation-documentation.md
@@ -11,6 +11,9 @@ eleventyNavigation:
     order: 1
     nav: guides-producteur
 pictogram: document/document-download.svg
+summary:
+    visible: true
+    depth: 2
 ---
 
 {% from "components/component.njk" import component with context %}
@@ -21,9 +24,9 @@ Cette page explique la procédure d’installation du projet de documentation de
 Cette documentation est technique mais vous permet de visualiser vos ajouts, modifications ou suppressions dans un navigateur avant d’en demander la fusion avec le dépôt principal _github_.
 :::
 
-## 1 - Installation de l’environnement de travail
+## Installation de l’environnement de travail
 
-### 1.1 - Prérequis
+### Prérequis
 
 Pour disposer d’un environnement de travail confortable, il est recommandé de disposer des logiciels suivants :
 
@@ -33,13 +36,13 @@ Pour disposer d’un environnement de travail confortable, il est recommandé de
 
 _Git_ et _NodeJS_ sont indispensables pour aller plus loin dans l’installation.
 
-### 1.2 - Variables d’environnement du compte
+### Variables d’environnement du compte
 
 Si vous travaillez derrière un _proxy_, il est nécessaire de vérifier vos variables d’environnement **de compte** (pas les variables système). Ajouter les variables **« HTTP_PROXY »** et **« HTTPS_PROXY »** si elles n’existent pas encore. Renseignez-vous auprès de votre _DSI_ si vous ne connaissez pas les valeurs à indiquer (ces variables sont propres à chaque organisme).
 
-## 2 - Installation de la documentation en local
+## Installation de la documentation en local
 
-### 2.1 - Dupliquer le dépôt (_fork_)
+### Dupliquer le dépôt (_fork_)
 
 Rendez-vous sur le _github_ du projet : <a href="https://github.com/IGNF/cartes.gouv.fr-documentation" target="_blank" rel="noopener noreferrer" title="https://github.com/IGNF/cartes.gouv.fr-documentation - ouvre une nouvelle fenêtre">https://github.com/IGNF/cartes.gouv.fr-documentation</a>. Il faut dupliquer le projet sur votre espace _Github_ afin de pouvoir faire les changements de votre côté, les prévisualiser, puis les soumettre au dépôt principal.
 
@@ -55,7 +58,7 @@ Votre _fork_/duplication du dépôt sera disponible sous l’URL **« https://g
 
 ![Image décrivant le résultat de la duplication](/img/guides-producteur/creer-des-pages-de-documentation/installation-documentation/02_Resultat-duplication.png){.fr-responsive-img .frx-border-img .frx-img-contained}
 
-### 2.2 - Cloner le dépôt sur votre ordinateur
+### Cloner le dépôt sur votre ordinateur
 
 Sous Windows, après avoir installé _Git for Windows_, vous devriez avoir accès au clic droit dans l’explorateur à un menu contextuel **« Git Bash here »** qui vous permet de lancer une invite de commande qui est très adaptée à l’utilisation de _Git_ et offre une bonne coloration syntaxique. Il est recommandé de la préférer à l’invite de commande par défaut de Windows.
 
@@ -75,7 +78,7 @@ git clone https://github.com/{votre_pseudo_github}/cartes.gouv.fr-documentation
 
 Votre _fork_ est maintenant cloné en local sur votre ordinateur.
 
-### 2.3 - Installer les dépendances
+### Installer les dépendances
 
 Déplacez-vous dans le dossier que vous venez de créer avec la commande suivante :
 

--- a/content/fr/guides-producteur/creer-des-pages-de-documentation/rediger-documentation.md
+++ b/content/fr/guides-producteur/creer-des-pages-de-documentation/rediger-documentation.md
@@ -12,6 +12,9 @@ eleventyNavigation:
     order: 3
     nav: guides-producteur
 pictogram: document/document.svg
+summary:
+    visible: true
+    depth: 2
 ---
 
 {% from "components/component.njk" import component with context %}
@@ -22,11 +25,11 @@ Cette page explique la procédure pour créer, modifier ou supprimer des pages d
 Avant de commencer vos modifications, pensez à effectuer les étapes préalables indiquées page précédente. Vous éviterez ainsi d’éventuels conflits.
 :::
 
-## 1 - Prévisualisation sur _VS Code_
+## Prévisualisation sur _VS Code_
 
 À la suite de l’installation de _VS Code_, vous pouvez prévisualiser l’écriture de contenu de plusieurs facons. Néanmoins, cette prévisualisation n’englobera pas les composants DSFR. Il faudra déployer le site en local pour avoir une image complète de prévisualisation (cf. page précédente).
 
-### 1.1 - Dans la même fenêtre _VS Code_
+### Dans la même fenêtre _VS Code_
 
 Cliquez sur le bouton de prévisualisation (ou utilisez les raccourcis claviers **« crtl+k »** puis **« V »**) :
 
@@ -34,15 +37,15 @@ Cliquez sur le bouton de prévisualisation (ou utilisez les raccourcis claviers 
 
 ![Image décrivant le résultat de l’opération précédente](/img/guides-producteur/creer-des-pages-de-documentation/rediger-documentation/02_Previsualisation_VS.png){.fr-responsive-img .frx-border-img .frx-img-contained}
 
-### 1.2 - Dans un autre onglet de _VS Code_
+### Dans un autre onglet de _VS Code_
 
 Utilisez les raccourcis clavier **« Ctrl + Shift + V »**
 
 ![Image décrivant le résultat de l’opération précédente](/img/guides-producteur/creer-des-pages-de-documentation/rediger-documentation/03_Previsualisation_VS.png){.fr-responsive-img .frx-border-img .frx-img-contained}
 
-## 2 - Effectuer des modifications
+## Effectuer des modifications
 
-### 2.1 - Modifier des fichiers
+### Modifier des fichiers
 
 Il vous suffit d’éditer, de créer ou de supprimer les fichiers dans votre dossier. Lorsque vous enregistrez, la modification est prise en compte par _Eleventy_ et s’affichera dans la prévisualisation en _localhost_ sur votre navigateur.
 
@@ -50,9 +53,9 @@ Il vous suffit d’éditer, de créer ou de supprimer les fichiers dans votre do
 la modification peut ne pas bien s’afficher dans le cas d’une création d’un nouveau fichier. Dans ce cas arrêtez _Eleventy_ en faisant **« ctrl+C »** dans l’invite de commande _Git Bash_, puis relancez la commande **« npm start »**
 :::
 
-### 2.2 - Structure
+### Structure
 
-#### 2.2.1 - Emplacement des modifications
+#### Emplacement des modifications
 
 En tant que rédacteur, vous n’aurez généralement pas de modification à effectuer hors de ces deux dossiers :
 
@@ -62,7 +65,7 @@ En tant que rédacteur, vous n’aurez généralement pas de modification à eff
 Le contenu de la barre de navigation n’est pas directement déterminée par l’arborescence des dossiers et fichiers mais par le contenu des cartouches (ou en-têtes) de chaque fichier.
 Il est toutefois conseillé d’avoir une arborescence qui corresponde à cette navigation pour faciliter le repérage.
 
-#### 2.2.2 - Nouveau partenaire
+#### Nouveau partenaire
 
 Pour ajouter un nouveau partenaire à la documentation, il faut ajouter un fichier _.md_ dans le dossier **« partenaires »**, contenant les informations suivantes :
 
@@ -129,7 +132,7 @@ Dans le fichier _parent.njk_ situé dans **« _includes/layouts »**, en rempl
 {% endraw %}
 ```
 
-#### 2.2.3 - Fichier .md parent
+#### Fichier .md parent
 
 Chaque dossier doit contenir un fichier _.md_ pour chacun de ses sous-dossiers, portant le même nom que celui-ci :
 
@@ -182,7 +185,7 @@ Voir paragraphe 2.4 pour plus de détails sur les pictogrammes.
 Attention : le menu latéral ne peut contenir que trois niveaux au maximum !
 :::
 
-#### 2.2.4 - Fichier .11data.js
+#### Fichier .11data.js
 
 Chaque sous-dossier doit contenir un fichier **« nom-du-dossier-parent.11tydata.js »** qui permet de déterminer l’arborescence des fichiers adjacents.
 
@@ -203,7 +206,7 @@ module.exports = {
 {% endraw %}
 ```
 
-#### 2.2.5 - Fichier .md décrivant le contenu de la page
+#### Fichier .md décrivant le contenu de la page
 
 Le texte est découpé en 2 parties : un en-tête (ou cartouche) qui contient les métadonnées de la page du site correspondant à ce texte, et le corps du texte. L’en-tête est similaire à celui des pages parents :
 
@@ -237,11 +240,11 @@ Le contenu des pages de documentation est rédigé en _markdown_ (_.md_), édita
 La syntaxe propre au <a href="https://fr.wikipedia.org/wiki/Markdown" target="_blank" rel="noopener noreferrer" title="Documentation Markdown - ouvre une nouvelle fenêtre">mardown</a> est relativement simple. Ci-dessous vous pouvez retrouver les différentes syntaxes à utiliser :
 
 ```markdown
-## 1 - Titre de niveau 1
+## Titre de niveau 1
 
-### 1.1 - Titre de niveau 2
+### Titre de niveau 2
 
-#### 1.1.1 - Titre de niveau 3
+#### Titre de niveau 3
 
 **texte en gras**
 _texte en italique_
@@ -305,7 +308,7 @@ Pour afficher un tableau
 Pensez à bien séparer le bloc image du texte précédent avec un saut de ligne et de garder les espaces tels que présentés ci-dessus.
 :::
 
-### 2.4 - Images et pictogrammes
+### Images et pictogrammes
 
 Les images sont stockées dans le dossier **« cartes.gouv.fr-documentation/public/img/partenaires/producteurABC/... »**. Il suffit de rajouter votre image dans le dossier correspondant.
 

--- a/content/fr/guides-producteur/presentation/generalites.md
+++ b/content/fr/guides-producteur/presentation/generalites.md
@@ -6,11 +6,13 @@ eleventyNavigation:
     order: 1
     nav: guides-producteur
 pictogram: map/location-france.svg
+summary:
+    visible: true
 ---
 
 {% from "components/component.njk" import component with context %}
 
-## 1 - Cartes.gouv.fr, le service public des cartes et données du territoire
+## Cartes.gouv.fr, le service public des cartes et données du territoire
 
 La carte est un outil de médiation majeur. Par sa capacité inégalée à montrer des phénomènes complexes, parfois peu visibles voire invisibles, elle est la plus efficace des invitations à nous faire agir. Dans le contexte actuel de changements rapides de notre environnement, la carte constitue un guide de lecture indispensable pour permettre à chacun de comprendre ces changements et de se les approprier pour faciliter la prise de décision et le passage à l’action.
 
@@ -18,13 +20,13 @@ L’IGN, service public de la cartographie, s’engage pour mettre à dispositio
 
 Le site se construit par briques et a vocation à reprendre progressivement les fonctions des sites geoportail.gouv.fr et geoservices.ign.fr ainsi que d’autres services de l’IGN <a href="#note-1">(1)</a>. Ainsi, la première interface de cartes.gouv.fr rassemblera début 2024 les premières briques disponibles de catalogage, d’alimentation/diffusion des données. De nouveaux services seront régulièrement ajoutés.
 
-## 2 - La Géoplateforme comme infrastructure et moteur pour répondre aux besoins des producteurs et des développeurs de services
+## La Géoplateforme comme infrastructure et moteur pour répondre aux besoins des producteurs et des développeurs de services
 
 En parallèle, l’IGN développe la Géoplateforme, une infrastructure ouverte et collaborative pour l’hébergement, le partage, le traitement et la mise en cartographie des géodonnées. Le site cartes.gouv.fr s’appuie sur cette nouvelle plateforme : il en est en quelque sorte la vitrine principale (mais pas exclusive) tout autant qu’un pupitre de commande accessible à tous. Les fonctionnalités de la Géoplateforme peuvent être utilisées sans passer par cartes.gouv.fr.
 
 Mise en œuvre par l’IGN avec le soutien du Ministère de la Transition écologique et de la Cohésion des territoires (MTECT) et du Fonds pour la transformation de l’action publique, la Géoplateforme s’inscrit dans la dynamique des géocommuns soutenue par l’institut. En effet, elle constitue en premier lieu un outil commun porté par un ensemble de partenaires, de producteurs et d’usagers de données parmi lesquels le MTECT, le Cerema, le CRIGE PACA, Géobretagne, INERIS, l’OFB, l’ONF ou le Shom.
 
-## 3 - Le profil producteur
+## Le profil producteur
 
 Cette partie du guide s’adresse aux producteurs de données, c’est-à-dire les personnes physiques ou morales qui souhaitent venir stocker des données sur la Géoplateforme en leur nom ou pour le compte de quelqu’un d’autre, et publier des services permettant d’accéder à ces données sous forme de flux WFS/WMS/WMTS/TMS.
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -17,6 +17,7 @@ const pluginCalendar = require("@codegouvfr/eleventy-plugin-calendar");
 const customMarkdownContainers = require("./markdown-custom-containers");
 
 const { translations } = require("./_data/i18n");
+const { getSummaryItems } = require("./utils.js");
 
 const fs = require("fs");
 const path = require("path");
@@ -201,6 +202,9 @@ module.exports = function (eleventyConfig) {
         const fullPath = path.join(__dirname, filePath);
         return fs.readFileSync(fullPath, "utf-8");
     });
+
+    // Get summary items (headers) from a content string
+    eleventyConfig.addFilter("getSummaryItems", getSummaryItems);
 
     eleventyConfig.addPairedShortcode("testpaired", async function (content = "", param1) {
         console.log(content);

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,6 @@ class Node {
         this.id = id;
         this.name = name;
         this.tagName = tagName;
-
         this.children = [];
     }
 
@@ -27,7 +26,6 @@ function insertNode(parent, node, level) {
         parent.addChild(node);
     } else {
         // sinon on continue à chercher le parent
-
         let lastChild = parent.children[parent.children.length - 1];
         let lastChildLevel = parseInt(lastChild.tagName.slice(1));
 
@@ -39,3 +37,45 @@ function insertNode(parent, node, level) {
         }
     }
 }
+
+/**
+ * Recherche les headings du document et les organise en une structure hiérarchique
+ * en fonction de la profondeur spécifiée.
+ * Ignore les headings qui sont des titres de composants (alert, tile, accordion)
+ * ne dépasse jamais 3 niveaux (h2, h3, h4) et ignore toujours le h1
+ * @param {string} content
+ * @param {number} depth
+ * @returns {array<Node>}
+ */
+const getSummaryItems = (content, depth = 1) => {
+    const { document } = new JSDOM(content).window;
+
+    switch (depth) {
+        case 1:
+            querySelector = "h2";
+            break;
+        case 2:
+            querySelector = "h2, h3";
+            break;
+        default: // depth 3 or more always equals 3 levels of summary
+            querySelector = "h2, h3, h4";
+    }
+
+    const headings = Array.from(document.querySelectorAll(querySelector)).filter(
+        (h) => !h.classList.contains("fr-tile__title") && !h.classList.contains("fr-alert__title") && !h.classList.contains("fr-accordion__title")
+    );
+
+    const root = new Node("root", "root", "root");
+
+    headings.forEach((heading, index) => {
+        const level = parseInt(heading.tagName.slice(1));
+        const node = new Node(heading.id, heading.textContent.replace(" #", ""), heading.tagName);
+        insertNode(root, node, level);
+    });
+
+    return root.children;
+};
+
+module.exports = {
+    getSummaryItems,
+};


### PR DESCRIPTION
Ajoute un sommaire entre le fil d'ariane et le corps des pages.

<img width="600" height="384" alt="image" src="https://github.com/user-attachments/assets/a7f08842-2d31-4733-80d3-7372e173eda5" />


Le sommaire est désactivé par défaut et doit être activé par l'ajout dans les métadonnées de : 

```yaml
summary:
    visible: true
    depth: 2
```

`depth` est optionnel et est par défaut de 1 et ne peut pas dépasser 3. Si un nombre supérieur à 3 est spécifié, seul les titres `h2`, `h3`, `h4` figureront dans le sommaire.

Le [composant sommaire du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/sommaire) utilisant une liste numérotée, il ne faut pas que les titres soient eux-même numérotés manuellement.

----

Le sommaire est appliqué dans une partie de la documentation producteur qui a été en partie revue à l'occasion.

----

Issue concernée : #166 