### PR TITLE
fix: logo ign as main partner

### DIFF
--- a/_includes/templates/footer.njk
+++ b/_includes/templates/footer.njk
@@ -47,15 +47,15 @@
         <div class="fr-footer__partners">
             <h2 class="fr-footer__partners-title">Nos partenaires</h2>
             <div class="fr-footer__partners-logos">
+                <div class="fr-footer__partners-main">
+                    <a class="fr-footer__partners-link" href="https://www.ign.fr">
+                        <img class="fr-footer__logo" style="height: 5.625rem"
+                             src="https://data.geopf.fr/annexes/ressources/footer/ign.png"
+                             alt="IGN"/>
+                    </a>
+                </div>
                 <div class="fr-footer__partners-sub">
                     <ul>
-                        <li>
-                            <a class="fr-footer__partners-link" href="https://www.ign.fr">
-                                <img class="fr-footer__logo" style="height: 5.625rem"
-                                     src="https://data.geopf.fr/annexes/ressources/footer/ign.png"
-                                     alt="IGN"/>
-                            </a>
-                        </li>
                         <li>
                             <a class="fr-footer__partners-link" href="https://www.transformation.gouv.fr/">
                                 <img class="fr-footer__logo" style="height: 5.625rem"


### PR DESCRIPTION
Conformité au DSFR, on passe le logo IGN à gauche dans la section `main`.
<img width="800" height="199" alt="image" src="https://github.com/user-attachments/assets/4382f72d-42b4-4d86-9dee-aaab7f88c286" />
