### PR TITLE
page extensions gpf et sdk (#234)

### DIFF
--- a/content/fr/guides-developpeur.md
+++ b/content/fr/guides-developpeur.md
@@ -8,28 +8,5 @@ eleventyNavigation:
     order: 3
     nav: main
 sidemenuNav: guides-developpeur
+description: Consultez nos guides, FAQ, tutoriels et documentations techniques pour vous accompagner dans la prise en main des outils de la Géoplateforme et cartes.gouv.fr.
 ---
-
-## Toutes les ressources techniques pour utiliser cartes.gouv.fr et les briques de la Géoplateforme
-
-Consultez nos guides, FAQ, tutoriels et documentations techniques pour vous accompagner dans la prise en main des outils de la Géoplateforme et cartes.gouv.fr.
-
-### Entrepôt Géoplateforme
-
-{% from "components/component.njk" import component with context %}
-
-<div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
-
-<div class="fr-col-md-6">
-
-{{ component("tile", {
-    url: false,
-    externalUrl: "https://geoplateforme.github.io/sdk-entrepot/",
-    title: "Documentation du SDK python",
-    description: "Pour consommer l'API Entrepôt plus facilement avec des scripts développés en python",
-    pictogram: "digital/coding.svg"
-}) }}
-
-</div>
-
-</div>

--- a/content/fr/guides-developpeur/entrepot.md
+++ b/content/fr/guides-developpeur/entrepot.md
@@ -10,7 +10,7 @@ tags:
     - Workflow d'alimentation
 eleventyNavigation:
     key: Concepts de l'Entrepôt
-    order: 5
+    order: 2
     nav: guides-developpeur
 pictogram: system/system.svg
 ---

--- a/content/fr/guides-developpeur/extension-geoplateforme-itowns.md
+++ b/content/fr/guides-developpeur/extension-geoplateforme-itowns.md
@@ -1,9 +1,0 @@
----
-title: Extension Géoplateforme pour iTowns
-eleventyNavigation:
-    key: Extension Géoplateforme pour iTowns
-    order: 3
-    nav: guides-developpeur
----
-
-Extension Géoplateforme pour iTowns

--- a/content/fr/guides-developpeur/extension-geoplateforme-leaflet.md
+++ b/content/fr/guides-developpeur/extension-geoplateforme-leaflet.md
@@ -1,9 +1,0 @@
----
-title: Extension Géoplateforme pour Leaflet
-eleventyNavigation:
-    key: Extension Géoplateforme pour Leaflet
-    order: 2
-    nav: guides-developpeur
----
-
-Extension Géoplateforme pour Leaflet

--- a/content/fr/guides-developpeur/extension-geoplateforme-openlayers.md
+++ b/content/fr/guides-developpeur/extension-geoplateforme-openlayers.md
@@ -1,9 +1,0 @@
----
-title: Extension Géoplateforme pour OpenLayers
-eleventyNavigation:
-    key: Extension Géoplateforme pour OpenLayers
-    order: 3
-    nav: guides-developpeur
----
-
-Extension Géoplateforme pour OpenLayers

--- a/content/fr/guides-developpeur/extensions-geoplateforme.md
+++ b/content/fr/guides-developpeur/extensions-geoplateforme.md
@@ -1,0 +1,23 @@
+---
+title: Extensions Géoplateforme
+eleventyNavigation:
+    key: Extensions Géoplateforme
+    order: 1
+    nav: guides-developpeur
+pictogram: digital/coding.svg
+description: Extensions facilitant l’accès aux ressources de la Géoplateforme pour les bibliothèques cartographiques Leaflet, OpenLayers et iTowns.
+---
+
+
+Ces extensions pour les bibliothèques cartographiques **Leaflet**, **OpenLayers** et **iTowns** proposent des classes et widgets utilisables en complément de la bibliothèque cartographique elle-même. Elles permettent notamment :
+
+* d’afficher simplement les couches WMTS et WMS délivrées par la Géoplateforme,
+* d’intégrer un widget de gestion d’empilement des couches,
+* d’intégrer une barre de recherche utilisant le service de géocodage IGN,
+* de faire des calculs d’itinéraires à partir du service de la Géoplateforme,
+* de faire des calculs d’isochrones / isodistances à partir du service de la Géoplateforme,
+* d’afficher l’altitude en un point de la carte à l’aide du service d’altimétrie de la Géoplateforme.
+* …
+
+Retrouvez leur documentation et des exemples d’utilisation ici :<br/>
+<a href="https://github.com/IGNF/geoportal-extensions/blob/develop/README.md" target="_blank" rel="noopener noreferrer" title="IGNF/geoportal-extensions sur GitHub - ouvre une nouvelle fenêtre">https://github.com/IGNF/geoportal-extensions/</a>

--- a/content/fr/guides-developpeur/openapi.md
+++ b/content/fr/guides-developpeur/openapi.md
@@ -6,7 +6,7 @@ tags:
     - Spécifications OpenAPI
 eleventyNavigation:
     key: Spécifications OpenAPI de l'API Entrepôt
-    order: 7
+    order: 3
     nav: guides-developpeur
 pictogram: custom/swagger.svg
 ---

--- a/content/fr/guides-developpeur/sdk-python.md
+++ b/content/fr/guides-developpeur/sdk-python.md
@@ -1,0 +1,13 @@
+---
+title: SDK Python pour l'Entrepôt
+eleventyNavigation:
+    key: SDK Python pour l'Entrepôt
+    order: 5
+    nav: guides-developpeur
+pictogram: digital/coding.svg
+description: Pour consommer l'API Entrepôt plus facilement avec des scripts développés en python
+---
+
+
+Retrouvez le SDK et sa documentation ici :<br/>
+<a href="https://geoplateforme.github.io/sdk-entrepot/" target="_blank" rel="noopener noreferrer" title="SDK Entrepôt sur GitHub - ouvre une nouvelle fenêtre">https://geoplateforme.github.io/sdk-entrepot/</a>

--- a/content/fr/guides-developpeur/sdk-web-geoplateforme.md
+++ b/content/fr/guides-developpeur/sdk-web-geoplateforme.md
@@ -1,9 +1,0 @@
----
-title: SDK web Géoplateforme
-eleventyNavigation:
-    key: SDK web Géoplateforme
-    order: 1
-    nav: guides-developpeur
----
-
-SDK web Géoplateforme

--- a/content/fr/guides-developpeur/tutoriels.md
+++ b/content/fr/guides-developpeur/tutoriels.md
@@ -8,7 +8,7 @@ tags:
 description: Accès au différents tutoriels, par type de données et d'usage
 eleventyNavigation:
     key: Tutoriels d'utilisation de l'Entrepôt
-    order: 6
+    order: 4
     nav: guides-developpeur
 pictogram: leisure/digital-art.svg
 ---


### PR DESCRIPTION
Par rapport au ticket j'ai gardé 2 pages au lieu d'une seule : 
* extensions géoplateformes (en premier)
*  SDK Python (en dernier pour arriver après la description des concepts de l'entrepôt et le swagger de l'API Entrepôt)

SDK python était mis très en avant dès l'accueil des guides développeur. C'est maintenant au même niveau que le reste.

<img width="780" height="862" alt="image" src="https://github.com/user-attachments/assets/5f9be78f-cedd-4a91-bfd7-799cf453a6d9" />
