### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/suivi.yml
+++ b/.github/workflows/suivi.yml
@@ -1,4 +1,6 @@
 name: Ajouter au projet "Suivi global Cartes.gouv" si label "suivi" est ajouté
+permissions:
+    contents: read
 
 on:
     issues:


### PR DESCRIPTION
Potential fix for [https://github.com/IGNF/cartes.gouv.fr-documentation/security/code-scanning/1](https://github.com/IGNF/cartes.gouv.fr-documentation/security/code-scanning/1)

To fix the problem, explicitly declare a least-privilege `permissions` block for the workflow or for the specific job so the automatically provided `GITHUB_TOKEN` does not inherit broad repository/organization defaults. Because the job’s purpose is to add issues to a GitHub Projects board (and uses a PAT for that), it likely only needs read access to repository contents via `GITHUB_TOKEN`, if anything.

The safest minimal change without altering functionality is:

- Add a root-level `permissions` block (between `name:` and `on:`) that restricts `GITHUB_TOKEN` to read-only repository contents: `permissions: contents: read`.
- This applies to all jobs (there is only one job) and does not interfere with the PAT in `secrets.ADD_TO_PROJECT_PAT`.

Concretely, in `.github/workflows/suivi.yml`:

- Insert:

```yaml
permissions:
    contents: read
```

after line 1 (the `name:` line) and before the `on:` block.

No new methods, imports, or definitions are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
