### PR TITLE
Correction des liens vidéos pour pointer vers l'annexe de data.geopf.fr.

### DIFF
--- a/content/fr/guides-utilisateur/rechercher-une-donnee/detail-jeu-de-donnees.md
+++ b/content/fr/guides-utilisateur/rechercher-une-donnee/detail-jeu-de-donnees.md
@@ -20,8 +20,7 @@ showDescription: false
         <p>Voir la transcription ci-dessous</p>
     </video>
     <figcaption class="fr-content-media__caption">
-        Détail d'une métadonnée catalogue
-        <a id="link-bdtopo-metadonnee" href="#" class="fr-link"></a>
+        Détail d’une métadonnée catalogue
     </figcaption>
 </figure>
 
@@ -98,7 +97,6 @@ La partie **Téléchargements et flux** se compose également de deux **vignette
     </video>
     <figcaption class="fr-content-media__caption">
         Panneau de personnalisation
-        <a id="link-bdtopo-telechargement" href="#" class="fr-link"></a>
     </figcaption>
 </figure>
 

--- a/content/fr/guides-utilisateur/rechercher-une-donnee/interface-generale.md
+++ b/content/fr/guides-utilisateur/rechercher-une-donnee/interface-generale.md
@@ -22,7 +22,6 @@ showDescription: false
     </video>
     <figcaption class="fr-content-media__caption">
         Lancer une recherche
-        <a id="link-lancer-une-recherche" href="#" class="fr-link"></a>
     </figcaption>
 </figure>
 


### PR DESCRIPTION
1. Les vidéos ont été raccourcies pour aller à l’essentiel.
2. Le logo IGN au début a été supprimé afin d’obtenir une capture d’écran plus accrocheuse.
3. Une voix a été ajoutée pour améliorer la vulgarisation du contenu.
4. Transfert des liens vers l’annexe de data.geopf.fr pour éviter d’occuper de l’espace de stockage dans le dépôt GitHub de la documentation.