### PR TITLE
feat: rendre la recherche de page moins sensible aux accents #267

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,39 +11,39 @@
             "dependencies": {
                 "@codegouvfr/eleventy-plugin-calendar": "^3.0.5",
                 "@codegouvfr/eleventy-plugin-i18n": "^0.1.3",
-                "jsdom": "^27.0.0",
-                "keycloak-js": "^26.2.2",
+                "jsdom": "^29.1.1",
+                "keycloak-js": "^26.2.4",
                 "swagger-ui": "^5.31.0"
             },
             "devDependencies": {
-                "@11ty/eleventy": "^3.0.0",
-                "@11ty/eleventy-img": "^5.0.0",
-                "@11ty/eleventy-navigation": "^0.3.5",
+                "@11ty/eleventy": "^3.1.5",
+                "@11ty/eleventy-img": "^6.0.4",
+                "@11ty/eleventy-navigation": "^1.0.5",
                 "@11ty/eleventy-plugin-bundle": "^3.0.0",
                 "@11ty/eleventy-plugin-rss": "^2.0.0",
                 "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
-                "@gouvfr/dsfr": "^1.14.3",
+                "@gouvfr/dsfr": "^1.14.4",
                 "@prettier/plugin-xml": "^3.4.2",
                 "chalk": "^5.0.0",
                 "husky": "^9.0.11",
-                "ics": "^3.8.1",
-                "lint-staged": "^16.0.0",
+                "ics": "^3.12.0",
+                "lint-staged": "^17.0.7",
                 "luxon": "^3.5.0",
                 "markdown-it-anchor": "^9.0.0",
-                "markdown-it-attrs": "^4.2.0",
+                "markdown-it-attrs": "^5.0.0",
                 "markdown-it-container": "^4.0.0",
                 "mermaid": "^11.0.0",
-                "pagefind": "^1.4.0",
-                "prettier": "^3.7.4"
+                "pagefind": "^1.5.0",
+                "prettier": "^3.8.3"
             },
             "engines": {
                 "node": ">=24.0.0"
             }
         },
         "node_modules/@11ty/dependency-tree": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@11ty/dependency-tree/-/dependency-tree-4.0.1.tgz",
-            "integrity": "sha512-6EPI9ZkGU4BX2KNZpWlf4WdV3vrmIWQpn//nAXicTzdPubI3jZlmFdqEv0Yj5M7oavRUGNzw9GbV9cBxhulZWw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@11ty/dependency-tree/-/dependency-tree-4.0.2.tgz",
+            "integrity": "sha512-RTF6VTZHatYf7fSZBUN3RKwiUeJh5dhWV61gDPrHhQF2/gzruAkYz8yXuvGLx3w3ZBKreGrR+MfYpSVkdbdbLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -51,9 +51,9 @@
             }
         },
         "node_modules/@11ty/dependency-tree-esm": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@11ty/dependency-tree-esm/-/dependency-tree-esm-2.0.3.tgz",
-            "integrity": "sha512-zlcfZq5WC9ksnLeLBROshNeE9P1jvOAPvUY9787cND/7SKf+QM7RGjNyF5taoCQww12B6Dx0Y9cwXsNbRipzlA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@11ty/dependency-tree-esm/-/dependency-tree-esm-2.0.4.tgz",
+            "integrity": "sha512-MYKC0Ac77ILr1HnRJalzKDlb9Z8To3kXQCltx299pUXXUFtJ1RIONtULlknknqW8cLe19DLVgmxVCtjEFm7h0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -64,45 +64,45 @@
             }
         },
         "node_modules/@11ty/eleventy": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.2.tgz",
-            "integrity": "sha512-IcsDlbXnBf8cHzbM1YBv3JcTyLB35EK88QexmVyFdVJVgUU6bh9g687rpxryJirHzo06PuwnYaEEdVZQfIgRGg==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.5.tgz",
+            "integrity": "sha512-hZ0g6MwZyRxCqXsPm82gIM304LraKbUz3ZmezOSjsqxttZG6cHTib3Qq8QkESJoKwnr+yX1eyfOkPC5/mEgZnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@11ty/dependency-tree": "^4.0.0",
-                "@11ty/dependency-tree-esm": "^2.0.0",
+                "@11ty/dependency-tree": "^4.0.2",
+                "@11ty/dependency-tree-esm": "^2.0.4",
                 "@11ty/eleventy-dev-server": "^2.0.8",
-                "@11ty/eleventy-plugin-bundle": "^3.0.6",
+                "@11ty/eleventy-plugin-bundle": "^3.0.7",
                 "@11ty/eleventy-utils": "^2.0.7",
                 "@11ty/lodash-custom": "^4.17.21",
-                "@11ty/posthtml-urls": "^1.0.1",
-                "@11ty/recursive-copy": "^4.0.2",
+                "@11ty/posthtml-urls": "^1.0.2",
+                "@11ty/recursive-copy": "^4.0.4",
                 "@sindresorhus/slugify": "^2.2.1",
                 "bcp-47-normalize": "^2.3.0",
                 "chokidar": "^3.6.0",
-                "debug": "^4.4.1",
+                "debug": "^4.4.3",
                 "dependency-graph": "^1.0.0",
                 "entities": "^6.0.1",
                 "filesize": "^10.1.6",
                 "gray-matter": "^4.0.3",
                 "iso-639-1": "^3.1.5",
-                "js-yaml": "^4.1.0",
+                "js-yaml": "^4.1.1",
                 "kleur": "^4.1.5",
-                "liquidjs": "^10.21.1",
-                "luxon": "^3.6.1",
-                "markdown-it": "^14.1.0",
+                "liquidjs": "^10.25.0",
+                "luxon": "^3.7.2",
+                "markdown-it": "^14.1.1",
                 "minimist": "^1.2.8",
-                "moo": "^0.5.2",
+                "moo": "0.5.2",
                 "node-retrieve-globals": "^6.0.1",
                 "nunjucks": "^3.2.4",
-                "picomatch": "^4.0.2",
+                "picomatch": "^4.0.3",
                 "please-upgrade-node": "^3.2.0",
-                "posthtml": "^0.16.6",
+                "posthtml": "^0.16.7",
                 "posthtml-match-helper": "^2.0.3",
-                "semver": "^7.7.2",
-                "slugify": "^1.6.6",
-                "tinyglobby": "^0.2.14"
+                "semver": "^7.7.4",
+                "slugify": "^1.6.8",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "eleventy": "cmd.cjs"
@@ -147,19 +147,20 @@
             }
         },
         "node_modules/@11ty/eleventy-fetch": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-4.0.1.tgz",
-            "integrity": "sha512-yIiLM5ziBmg86i4TlXpBdcIygJHvh/GgPJyAiFOckO9H4y9cQDM8eIcJCUQ4Mum0NEVui/OjhEut2R08xw0vlQ==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-5.1.2.tgz",
+            "integrity": "sha512-YxDARdR3S9UT4gOGRWgGNyokYT9jkCAjJge3OVKFdNMv1cyvWg1NHCvj9NVvK9XHenCLFy3cwvM/YYpZZTZopw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "debug": "^4.3.4",
-                "flat-cache": "^3.0.4",
-                "node-fetch": "^2.6.7",
-                "p-queue": "^6.6.2"
+                "@11ty/eleventy-utils": "^2.0.7",
+                "@rgrove/parse-xml": "^4.2.0",
+                "debug": "^4.4.3",
+                "flatted": "^3.4.2",
+                "p-queue": "6.6.2"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             },
             "funding": {
                 "type": "opencollective",
@@ -167,18 +168,18 @@
             }
         },
         "node_modules/@11ty/eleventy-img": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy-img/-/eleventy-img-5.0.0.tgz",
-            "integrity": "sha512-hJ4X5ZIRSOCooL0uXegj+nZi1abWNj22BR4PzF6e9iJg9DGYGxPrC0rg0Hy+7xzP7mzTYiOpDjZVv/NgrHNx6w==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-img/-/eleventy-img-6.0.4.tgz",
+            "integrity": "sha512-jSy9BmubVs0mN76dcXWfSYDgRU+1+/rq/SxUR3MgIvTUAJRDop5pFW+Z1f56CDcOlEHaiPqHgnfOlqRmJvXl7g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@11ty/eleventy-fetch": "^4.0.1",
-                "@11ty/eleventy-utils": "^1.0.3",
+                "@11ty/eleventy-fetch": "^5.1.0",
+                "@11ty/eleventy-utils": "^2.0.7",
                 "brotli-size": "^4.0.0",
-                "debug": "^4.3.7",
-                "entities": "^5.0.0",
-                "image-size": "^1.1.1",
+                "debug": "^4.4.0",
+                "entities": "^6.0.0",
+                "image-size": "^1.2.1",
                 "p-queue": "^6.6.2",
                 "sharp": "^0.33.5"
             },
@@ -190,58 +191,18 @@
                 "url": "https://opencollective.com/11ty"
             }
         },
-        "node_modules/@11ty/eleventy-img/node_modules/@11ty/eleventy-utils": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-1.0.3.tgz",
-            "integrity": "sha512-nULO91om7vQw4Y/UBjM8i7nJ1xl+/nyK4rImZ41lFxiY2d+XUz7ChAj1CDYFjrLZeu0utAYJTZ45LlcHTkUG4g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "normalize-path": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/11ty"
-            }
-        },
-        "node_modules/@11ty/eleventy-img/node_modules/entities": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-5.0.0.tgz",
-            "integrity": "sha512-BeJFvFRJddxobhvEdm5GqHzRV/X+ACeuw0/BuuxsCh1EUZcAIz8+kYmBp/LrQuloy6K1f3a0M7+IhmZ7QnkISA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
         "node_modules/@11ty/eleventy-navigation": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@11ty/eleventy-navigation/-/eleventy-navigation-0.3.5.tgz",
-            "integrity": "sha512-4aKW5aIQDFed8xs1G1pWcEiFPcDSwZtA4IH1eERtoJ+Xy+/fsoe0pzbDmw84bHZ9ACny5jblENhfZhcCxklqQw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-navigation/-/eleventy-navigation-1.0.5.tgz",
+            "integrity": "sha512-zb6xe29cM9viSdYtZywKIkJw2HIROyBINdBcFWC9uD0c/jYOTAex5nwy3HNEuh5t6/Ld/S9V4gEizfmeYuYpCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "dependency-graph": "^0.11.0"
+                "dependency-graph": "^1.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/11ty"
-            }
-        },
-        "node_modules/@11ty/eleventy-navigation/node_modules/dependency-graph": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
-            "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6.0"
             }
         },
         "node_modules/@11ty/eleventy-plugin-bundle": {
@@ -339,26 +300,20 @@
             }
         },
         "node_modules/@11ty/recursive-copy": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.3.tgz",
-            "integrity": "sha512-SX48BTLEGX8T/OsKWORsHAAeiDsbFl79Oa/0Wg/mv/d27b7trCVZs7fMHvpSgDvZz/fZqx5rDk8+nx5oyT7xBw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.4.tgz",
+            "integrity": "sha512-oI7m8pa7/IAU/3lqRU9vjBbs20iKFo7x+1K9kT3aVira6scc1X9MjBdgLCHzLJeJ7iB6wydioA+kr9/qPnvmlQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
                 "errno": "^1.0.0",
                 "junk": "^3.1.0",
-                "maximatch": "^0.1.0",
+                "minimatch": "^3.1.5",
                 "slash": "^3.0.0"
             },
             "engines": {
                 "node": ">=18"
             }
-        },
-        "node_modules/@acemir/cssom": {
-            "version": "0.9.29",
-            "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.29.tgz",
-            "integrity": "sha512-G90x0VW+9nW4dFajtjCoT+NM0scAfH9Mb08IcjgFHYbfiL/lU04dTF9JuVOi3/OH+DJCQdcIseSXkdCB9Ky6JA==",
-            "license": "MIT"
         },
         "node_modules/@antfu/install-pkg": {
             "version": "1.1.0",
@@ -375,29 +330,44 @@
             }
         },
         "node_modules/@asamuzakjp/css-color": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
-            "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
             "license": "MIT",
             "dependencies": {
-                "@csstools/css-calc": "^2.1.4",
-                "@csstools/css-color-parser": "^3.1.0",
-                "@csstools/css-parser-algorithms": "^3.0.5",
-                "@csstools/css-tokenizer": "^3.0.4",
-                "lru-cache": "^11.2.4"
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/@asamuzakjp/dom-selector": {
-            "version": "6.7.6",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
-            "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
             "license": "MIT",
             "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
                 "@asamuzakjp/nwsapi": "^2.3.9",
                 "bidi-js": "^1.0.3",
-                "css-tree": "^3.1.0",
-                "is-potential-custom-element-name": "^1.0.1",
-                "lru-cache": "^11.2.4"
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/@asamuzakjp/nwsapi": {
@@ -416,9 +386,9 @@
             }
         },
         "node_modules/@babel/runtime-corejs3": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-            "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+            "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
             "license": "MIT",
             "dependencies": {
                 "core-js-pure": "^3.48.0"
@@ -434,47 +404,22 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@chevrotain/cst-dts-gen": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
-            "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
-            "dev": true,
-            "license": "Apache-2.0",
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "license": "MIT",
             "dependencies": {
-                "@chevrotain/gast": "11.1.2",
-                "@chevrotain/types": "11.1.2",
-                "lodash-es": "4.17.23"
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
             }
-        },
-        "node_modules/@chevrotain/gast": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
-            "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/types": "11.1.2",
-                "lodash-es": "4.17.23"
-            }
-        },
-        "node_modules/@chevrotain/regexp-to-ast": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
-            "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
-            "dev": true,
-            "license": "Apache-2.0"
         },
         "node_modules/@chevrotain/types": {
             "version": "11.1.2",
             "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
             "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/@chevrotain/utils": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
-            "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -531,9 +476,9 @@
             }
         },
         "node_modules/@csstools/color-helpers": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
             "funding": [
                 {
                     "type": "github",
@@ -546,13 +491,13 @@
             ],
             "license": "MIT-0",
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@csstools/css-calc": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
             "funding": [
                 {
                     "type": "github",
@@ -565,17 +510,17 @@
             ],
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.5",
-                "@csstools/css-tokenizer": "^3.0.4"
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
             }
         },
         "node_modules/@csstools/css-color-parser": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+            "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
             "funding": [
                 {
                     "type": "github",
@@ -588,21 +533,21 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/color-helpers": "^5.1.0",
-                "@csstools/css-calc": "^2.1.4"
+                "@csstools/color-helpers": "^6.0.2",
+                "@csstools/css-calc": "^3.2.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.5",
-                "@csstools/css-tokenizer": "^3.0.4"
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
             }
         },
         "node_modules/@csstools/css-parser-algorithms": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
             "funding": [
                 {
                     "type": "github",
@@ -614,17 +559,18 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "@csstools/css-tokenizer": "^3.0.4"
+                "@csstools/css-tokenizer": "^4.0.0"
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.0.21",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.21.tgz",
-            "integrity": "sha512-plP8N8zKfEZ26figX4Nvajx8DuzfuRpLTqglQ5d0chfnt35Qt3X+m6ASZ+rG0D0kxe/upDVNwSIVJP5n4FuNfw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+            "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
             "funding": [
                 {
                     "type": "github",
@@ -636,14 +582,19 @@
                 }
             ],
             "license": "MIT-0",
-            "engines": {
-                "node": ">=18"
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@csstools/css-tokenizer": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
             "funding": [
                 {
                     "type": "github",
@@ -655,8 +606,9 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@emnapi/runtime": {
@@ -670,10 +622,27 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+            "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@gouvfr/dsfr": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.14.3.tgz",
-            "integrity": "sha512-UTplClQLp635J4vRHx/rJ7SKEi+bepc1FisvzTS8efQGQ3Gm8LttZf11NJ+4XhEMYLbCf8TBvFFwWBZ9ztRFkg==",
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.14.4.tgz",
+            "integrity": "sha512-Ca17apmTyAF2tMFwMcLwQN7fTlbfMFeyYSLUIUmjoSg1XVF4vDDkbvvKBpWJWaoTLDSFZBbvvHzcDyxw9wSkLA==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "engines": {
@@ -1080,19 +1049,19 @@
             }
         },
         "node_modules/@mermaid-js/parser": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.0.tgz",
-            "integrity": "sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+            "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "langium": "^4.0.0"
+                "@chevrotain/types": "~11.1.1"
             }
         },
         "node_modules/@pagefind/darwin-arm64": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
-            "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+            "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1104,9 +1073,9 @@
             ]
         },
         "node_modules/@pagefind/darwin-x64": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
-            "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+            "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
             "cpu": [
                 "x64"
             ],
@@ -1118,9 +1087,9 @@
             ]
         },
         "node_modules/@pagefind/freebsd-x64": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
-            "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+            "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
             "cpu": [
                 "x64"
             ],
@@ -1132,9 +1101,9 @@
             ]
         },
         "node_modules/@pagefind/linux-arm64": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
-            "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+            "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
             "cpu": [
                 "arm64"
             ],
@@ -1146,9 +1115,9 @@
             ]
         },
         "node_modules/@pagefind/linux-x64": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
-            "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+            "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
             "cpu": [
                 "x64"
             ],
@@ -1159,10 +1128,24 @@
                 "linux"
             ]
         },
+        "node_modules/@pagefind/windows-arm64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+            "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@pagefind/windows-x64": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
-            "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+            "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
             "cpu": [
                 "x64"
             ],
@@ -1184,6 +1167,16 @@
             },
             "peerDependencies": {
                 "prettier": "^3.0.0"
+            }
+        },
+        "node_modules/@rgrove/parse-xml": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-4.2.0.tgz",
+            "integrity": "sha512-UuBOt7BOsKVOkFXRe4Ypd/lADuNIfqJXv8GvHqtXaTYXPPKkj2nS2zPllVsrtRjcomDhIJVBnZwfmlI222WH8g==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@scarf/scarf": {
@@ -1227,13 +1220,13 @@
             }
         },
         "node_modules/@swagger-api/apidom-ast": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.6.0.tgz",
-            "integrity": "sha512-ez1KnBdAzoh5a6ijDXzu5nADkVZXlnL1RkLl8n2u2tjiNg9597xxmFdEHLVa31Vxr1yYj0WtYGLA5e2Kp0KNrQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.1.tgz",
+            "integrity": "sha512-5vcFzXltmIpCsjQouVKzjj7pPPUxYmwIARHuenim96GDnmqqVTtAoBXpIX++cD5RcJA72EBEqepQ+VSAA12RPA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-error": "^1.6.0",
+                "@swagger-api/apidom-error": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1241,14 +1234,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-core": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.6.0.tgz",
-            "integrity": "sha512-gA1MVoXe19sjFLKGkWxp5VvSw3Tk0CSChfItJjFeFHpLSGrfm+LlXp37TmNSns53Ky0F7x7TB/5kAX5I/TO4xw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.1.tgz",
+            "integrity": "sha512-KsN0dZBsutUGWtbsqBMvQ+3pJUjq/wRRABCNIG2Ys/1Ctq8FaQaA0MoICPuYgDZCUNsZuJYbw6Swm6e0GaHWtA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
+                "@swagger-api/apidom-ast": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "minim": "~0.23.8",
                 "ramda": "~0.30.0",
@@ -1258,37 +1251,37 @@
             }
         },
         "node_modules/@swagger-api/apidom-error": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.6.0.tgz",
-            "integrity": "sha512-xp/cQ1xQ/4Vd/hhQfONK7ea9oVc3JUXAYyfRzvDR0lxISly/SyD2jMcqXzHtrylBAnv7V2HSsbC1BWo7ZJDLSQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.1.tgz",
+            "integrity": "sha512-7KV2Ac4BOcrv4yJz7T5DbZiTdqbnVUT+g68Hjhabl5zhD28mfEEn9V8Zq2D6rtjlCYkqWAMFb8Y6Y+9ssH5wgA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.20.7"
             }
         },
         "node_modules/@swagger-api/apidom-json-pointer": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.6.0.tgz",
-            "integrity": "sha512-RO6P5Gt64AnthGXKeqIFjQCLVFbAJvLYAb67TkvRQ9US4lNixFtFsYJnhLCC4ymz4dTT1hacG0cmTRGcEHF9ig==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.1.tgz",
+            "integrity": "sha512-c8QSUgQxDolTO+rP2bvX4CrZOrnTMTAMh0xGq8LaYvzVzs0bQT7ZApsbcA/4bzWlwcg6wy2Uuw+qMadl1FNR3w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
                 "@swaggerexpert/json-pointer": "^2.10.1"
             }
         },
         "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.6.0.tgz",
-            "integrity": "sha512-EYJfQ4JYuUo2J4QiiLnA/8LmM1k7AQcf1XVE+NrIpZ1160GIzqE+W5uOXkhAOImkP2Cb7EZZdE2cFE/tMYxNvw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.1.tgz",
+            "integrity": "sha512-2K3Ix+nRHDkuixkZ4FAMWY5MAJHipzpFvZrRtneZ7hsx7nObw9HYEXZw/yXuYrvnhC8jsE4z91Gwuvvz7ZjfPw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1296,15 +1289,15 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-arazzo-1": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.6.0.tgz",
-            "integrity": "sha512-5rF8PyBiIHh6NfC5Y0WypW11X6hQIWr88EKNOQbBuT/nnzAsOznrUCfQ99FYGLucwdOHaMIBn/b/n4ejGBto/A==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.1.tgz",
+            "integrity": "sha512-rnICw0uXnKeNHUaS+Ip7lxtVXqH1iA3zFlX446e4XAamJd6yU28sujIsGiZ71qPQ217teidkfK7Bx7MktHdiEw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1312,15 +1305,15 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.6.0.tgz",
-            "integrity": "sha512-tOodfX+o7lonEAnSAxet7nCayW+EqtKPegT06WXt7Llq1LS9eYZ9YzXdFgIwCm8UzfEpZdVLqtxbdLX9vuUtSg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.1.tgz",
+            "integrity": "sha512-syABiWLeWRfKoonUhPriPVwDDeEOlN5RD20Dj/MS9DT5r1BJUrAB1BfRRRHsVhzaXVdUcKKH99iC9C842J9kvA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1328,15 +1321,15 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.6.0.tgz",
-            "integrity": "sha512-lRMvwTdtuPcwJEYLTX/UGtECpHi9UNYeT9rmWMw3LiKZrZzYc2L8q4ipPbpWwH8t7QfsF2u0iggCODU99lXCnw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.1.tgz",
+            "integrity": "sha512-y4syE8jOEGuSirc3YaeI0dh3rEvHfc/pERQOTj3KofS2IABpBXTmtg+oDfG2zte1/Cyc/eJ6qecVAns5mhBpow==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1344,15 +1337,15 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.6.0.tgz",
-            "integrity": "sha512-dee1i8wcAFgDEOzTsyoCzQhFLZ2JKzkK5KkRuryabvwS0hG2mKlogToFc8cO2MkkiLSpERm7DREALwSTFVHa0w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.1.tgz",
+            "integrity": "sha512-1SNXikZN2uQ1YZ3A4dzWBoMN6wTkba1qZdy/NOkweFtoLuBb63KKN/gD1e6chQV8+ikqGn8TTUZnYvX6SVBZ6g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1360,15 +1353,15 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.6.0.tgz",
-            "integrity": "sha512-ldTxSnnIXskwpN6yCJkasqs32pJXwoXyad95crKT0xjZZr4fTrcAXXIyzdjBubiY9tK6elSrQGQxinJcV7ivWw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.1.tgz",
+            "integrity": "sha512-oyvTkjDXI9k3G8oVHOvpL/t1MfZmx8d7rgeNqsm6j/vK6WlOXIOHdN9LTYRo8YdACaWq/JV5B30grkio/HRMKQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-2019-09": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1376,14 +1369,14 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.6.0.tgz",
-            "integrity": "sha512-t9HvHwrevEG7usosO6AdXmC8oYqje5nxHpUmODr72tUtCeAeGEGEb9lgqx7fBhjc3BYsRzOL1hX56m1gjEyCog==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.1.tgz",
+            "integrity": "sha512-Ha23zkVSItmFZbAoSKMI7hwYJT7yTMWO+EcNzDBEClsqRrkcCtvF2YsiQZcyUt5SrEwV8rW0TWE0CVG+WEs2zg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.6.0",
-                "@swagger-api/apidom-core": "^1.6.0",
+                "@swagger-api/apidom-ast": "^1.11.1",
+                "@swagger-api/apidom-core": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1391,15 +1384,15 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.6.0.tgz",
-            "integrity": "sha512-aoyvQWgAOcZGTe5OfJ3r24DvXHHbrkKtAnxTOEdZzV/uOm6/cbuT8m02+aMOqWPxei1naC3ZHW9iHrETtfgV3w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.1.tgz",
+            "integrity": "sha512-Gm4ULCg4yulfjZiMIbH1XiiKHI/BqK0zc1GexViiLShXS35/2dc27GmpI0YgV7S+DqvivNrwAkqojeN7ho9/NA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1407,15 +1400,15 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.6.0.tgz",
-            "integrity": "sha512-GjmC4+AHQh22fRZOmV+jSYMJTXh243XvdACfIQ//39kQu7gQsimF4PVSY2IgWSvS/I1ukWdPBYmDvOKryBPGrw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.1.tgz",
+            "integrity": "sha512-OHW4Qb0BqbHJ3QoQcGREE5bobMeBkZzSQe/0RFGayhI1HJZqrmwtot2nLAuie9sQJoj/xeUprOsA/he06NVFEw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1423,16 +1416,16 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-openapi-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.6.0.tgz",
-            "integrity": "sha512-xbmYzagnB8rO7sYwNGVyxYbNBkjCWnMhlnMrxkPtfQ/2u2ANAmTnCB/S/cMswX5XofiRJbznKAjLDSKBS+mLpQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.1.tgz",
+            "integrity": "sha512-yXHJmyN+NyF2xBD6KlFmGuMrf1hKqK9pm/FwStepIUqvn6bfTGgEdUi5BivQuErRrN6NtQczFF21Jlu6jjg86Q==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1440,15 +1433,15 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.6.0.tgz",
-            "integrity": "sha512-AOvW7a2H27inepcTBAWaBMjJLrCh5IPWD4nTU+gysULC7IW6gphO8hj3iUuTmFBcGh9be89GBbvv2y/EGAfx9w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.1.tgz",
+            "integrity": "sha512-R2zHd33OiVT5eTlYKS1FyVDP0G76ymdP2EIrBPbM1FDKam1kRIRdgZA2StCd9PY4oNp/LqQKMnfe9wdLWZS3AA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1456,17 +1449,17 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.6.0.tgz",
-            "integrity": "sha512-jCVypc8503zDSxAQlyV8j1vzwc75VBdWHtE2O0F+q5j9qNtGxw/ekbDkgrydYRaGBl92mf16dtPjtp5LwJD0Hw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.1.tgz",
+            "integrity": "sha512-FtoW4wkFO1VSHu6G+wUZ71hQhIOuastJPyWEePbfySE4Uiz+01t/X/ODnl2OHRGVUYFoJa7kJi5/xqcsprdxtA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.6.0",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-json-pointer": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
+                "@swagger-api/apidom-ast": "^1.11.1",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-json-pointer": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1474,18 +1467,18 @@
             }
         },
         "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.6.0.tgz",
-            "integrity": "sha512-QcFAUucaPaWiOKOEaaGqSfK3OtjeGJodWZLsuBQ0vrHaHkWyQ7jwsM1DJbc1Y8geOBeD2wIwdrdRjoulmqU1SA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.1.tgz",
+            "integrity": "sha512-ILJAgp6mHwoV8rRuKYD3QuvPdcRcmK9YmAfrsjgC7fJM7irqzC+nBOKhrWVpTAee7r3b+B3HpV5MG8aKGd9qNQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.6.0",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-json-pointer": "^1.6.0",
-                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
+                "@swagger-api/apidom-ast": "^1.11.1",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-json-pointer": "^1.11.1",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1493,144 +1486,144 @@
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.6.0.tgz",
-            "integrity": "sha512-vz/9k0X/kh6mLm+Fi+LGNk/yyFq28wxI29ZVLW+b7ulcODikv+NaDnyN2n2kLKCvIchPATzAEvqMvVMuuQwWlg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.1.tgz",
+            "integrity": "sha512-bCt1/7NPfCznhq2D3Y1UcZowdxMtr6wGCISMSPf3ziaCcOQhy7sG/nWEzS/rwcKCVNefVft833Ab3jaCWGivJw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-api-design-systems": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.6.0.tgz",
-            "integrity": "sha512-QAq4H6YzRtysSpvLtlJ8WZ22/1Mht+/iarrUOijxDZQPAGfYeUoIicnCqxkVZYSea85sQl+3kiCCB3nhSH+L0g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.1.tgz",
+            "integrity": "sha512-hUcshr5ydn/L4VsgP5nyrFDp4QqIADrx5nQnFddw/OWCNi1Al19ccPxuBh1Qlf421AAmk1oUiybeGyduvRsVPQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-api-design-systems": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.6.0.tgz",
-            "integrity": "sha512-syKPG3a9IGRvlGhXIEUzWhwbEuFbj+UwwtqaKu8zu771V+DRtH+wxyOkX54vKAIlApz/FgeUbmlWA1ZtYBlSIQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.1.tgz",
+            "integrity": "sha512-8ydiEnlSJ7DPhFqg9Z11u4Vda16yaOuIGLablI0mOnYoAMTlqnteGk5CDPlVb970VBTYvsNlgW+164XfHAU/6w==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-arazzo-1": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.6.0.tgz",
-            "integrity": "sha512-IVVLn+a8Q1iQcQsm4tXiAPghHJuJSB1rhIlDyHe3tSQgt9HOSiVpbnJDpwE/JBxxDxSAkeT6Ovo+fi2T5AmHYg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.1.tgz",
+            "integrity": "sha512-G4++rZDMKokEfq78EJ2aE7pgd1Xo70XIn1/ikSiT5awfuhPJzNcV99ZdzQI2xVVU/pbKIL2Vc/b5SP1IRlfCwA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-arazzo-1": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.6.0.tgz",
-            "integrity": "sha512-aSUi22ELTDvdCLA3nIUOehuNBcHSeCqU7S7YNiHP/mwE4Q07pwQrYXijH2PROfCdjlZNNN34m6Ptakd92jliJQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.1.tgz",
+            "integrity": "sha512-7Npn4LkG4q95b2VimG3SV0lqgG3xPeF5Srq+sVbG7iFd4yDubvEVy5zzqx5QH4tOtATdarhv6glA9j3hTfWBdQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.6.0.tgz",
-            "integrity": "sha512-Ic53vcFF9zniDyCXOGSwwuAdEBUn5lFEAa0m2i30R36cQFHBCCuvbzbMQjWdr+oML0Aw4XoqOwZCQgkJJICpPA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.1.tgz",
+            "integrity": "sha512-/C1CzsnUW2ZMBg4kWYrhrfqmyjb4aGo9+YaySQwdArLfM8l2HCOQqDEteGIivedVEsmTpVdhC60gdb6N2VzSaQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-asyncapi-3": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.6.0.tgz",
-            "integrity": "sha512-d/w7X+T4vT+KPqb+8xUm6n4pbHsGB28jdxE9rNVbxhu6D3owny2uxfglwaFh4fJG6FQMavCwl/QzfB4newdoKQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.1.tgz",
+            "integrity": "sha512-0Xfu8PLM787el0R7lwjFfQYe0Bpv3Jz0YlkEiQqAVvftVb0oNi8tg9FhDTR8ju/N94gpNXIfaH/5Ahgz5G+NKg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.6.0.tgz",
-            "integrity": "sha512-Wmf0LY59TZxQhqrJU2pcnUikcChVB4IqGPgjtOFLUoqPpz8FSwYbJ/SPnSMSl+QuncxROheSFsgZ6Tupv0sPHw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.1.tgz",
+            "integrity": "sha512-DqoR43NsFBmiJW1h2Xg3n2V6NQx+95qJ3ziA9rIbKJHGCidHtjNJgi4I7sWGnaIApIHijYY2bW22MKXaT0a0cQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-asyncapi-3": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-json": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.6.0.tgz",
-            "integrity": "sha512-WdAS+dBAB2t18HuUgSZy5b8JM7uXfn1RlPymJNRMUsrKYCTtPrQ/0q3YfnBjPhtjSSNCp+p1wajxHAFS7cj2VA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.1.tgz",
+            "integrity": "sha512-L8XFzTbEknHDhD40M/pSoDlimjlYaXXWZS4AmyD3i+XRfiDWWVhEWHPE9OTNk6UL8R6DOBm3RSDxAd5xpLoPjg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.6.0",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
+                "@swagger-api/apidom-ast": "^1.11.1",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0",
@@ -1640,144 +1633,144 @@
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.6.0.tgz",
-            "integrity": "sha512-Q36W1FzdVaY7Oh98533dzCUghwb8k3ZMdlnV37V1H13FlUkj3tVZiWaeaCLwIakzQ7XXYaQTOP+VrRhDRjzhUA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.1.tgz",
+            "integrity": "sha512-s9xZa/h4Yiz+Qc304s+9JSTPFsToYtSWQCeyA9jkHOWy/Oq8ZjD9wg34IjENS3yBqM1YLz6Dk+PX06DcyAOnnw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.6.0.tgz",
-            "integrity": "sha512-UY+obOLTPHJvnXscdMY9XwZyuqcnBe6cu9TURjJgkO/QpOpPDqqZoRyurKZgRrX0Pv9B1zR3EIzhl01u/jeUaw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.1.tgz",
+            "integrity": "sha512-dLGaVn24N+YZRB0vzQMC4R+aiSNfD81Xcp5TwdEbE+jOeOnoOe5NqzqCWjaDpSMChDsK/NdaSDjQj4uiYfWpug==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.6.0.tgz",
-            "integrity": "sha512-4ch04/96lYMXQu6odqa6H0aJmV8UefnBJKX1CPuL4qcPSPMFCurcXHGpPHrwMu1p/4Q9H+yRVlYeNQV10xvM0w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.1.tgz",
+            "integrity": "sha512-EnYF3rzPZoiCYDnp4ChB6K15RUV4rE6QfEh7fTEwIlkWMUKv4oVwZd8aqz2i9laRZiBH6S2uUoED8YNtCNbeIg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.6.0.tgz",
-            "integrity": "sha512-fWR2gjMQg00QIimcXQMSVeLnCH/2iuDD/Dx8TzVHmKV/IKlu+TnmIVosdlDfRmOB+4duwU6/yfoA79IEhFeZdw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.1.tgz",
+            "integrity": "sha512-digw37g+k/rg87HHMUHuSZVWH1Kh8OjC8SmQflIh1Oot9fGhmnZWddsws+sKWSVy6/HveuZPykL8bxtSV3Nc/A==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.6.0.tgz",
-            "integrity": "sha512-dkEh1Rw9uvuIAOTfKjWRX2rLWP+xJ/Eqdkqeo0I0BWFKXX49YcDpHJV4XHpmd5FbsjJ9vBYr0hAmkbl32TtR4g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.1.tgz",
+            "integrity": "sha512-b38GFur/NjjLFBCVR/wo7DRF6EW5h8B5jBe7C17EVaJvg9eRzknnr9/KMnxYeTtjQVO8W/JeY7LlLad1/j0pcA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.6.0.tgz",
-            "integrity": "sha512-6azq5YonWdzHcO9llK9zn1a+rGxlTz2Uf8p8NWDQnl2AZ56neDLYEL3mNDlrMXAy8dSJIHw+u9VF1OOzdslIHQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.1.tgz",
+            "integrity": "sha512-dza6Bwe5kLL+4jANuaScxvYh3o7RxESp6Riz6M09cXRysyRrHFQ7UYuUhxepSD4jSiSxJQS8nu0i547i6Z7W7Q==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.6.0.tgz",
-            "integrity": "sha512-g2tGCXyIAC0IA6JjA0HVxHWyCovyfAxDQ+pMAJ6qm4PfrZHB+oXKWKZHNNmQaFiKdc/SVdMQq6Up0mXOQs7IOQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.1.tgz",
+            "integrity": "sha512-PgmolQN1PYdROSo/cHNyXINVD+aLmW6VqfwT7potNo08c4aWj+QQ/a0Az+mldfJ+G98WjNRvEKr8dhEw8zfqmw==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.6.0.tgz",
-            "integrity": "sha512-NGkdG9X5Svi89ZBluNseyUBNdgB9MkbTTNmerVKKOmCCHaVbzIb6UFPXf1MifSFyT+wTeGZk6WZLgRIDsTAZ5Q==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.1.tgz",
+            "integrity": "sha512-+nmtJ3/wPLBBN6d8xI8rD0mOz80V4iSRe6rYYOQ/skel673N1SY4B58Ufnc7KnMNV4cOce/a52ASQ1Qd1csLvQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             }
         },
         "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.6.0.tgz",
-            "integrity": "sha512-UwSE5pPUJ+ag7ZCbesgx/SJ8zUD3Sx+2U4AD3/1G1EJ+0gb7FMYgihuOT8ujmBfZVGGm3HMIEIa1w3zha08v2g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.1.tgz",
+            "integrity": "sha512-KEgk5PoSmmLC7ZvH0+RF4FPyWAj0NyrPFbTr04DmNPznfr2qpGqvt3ZBmAJm82jrWoI1dc8EH1ugT1YX69N8ww==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-ast": "^1.6.0",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
+                "@swagger-api/apidom-ast": "^1.11.1",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
                 "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
                 "@types/ramda": "~0.30.0",
                 "ramda": "~0.30.0",
@@ -1806,59 +1799,47 @@
                 }
             }
         },
-        "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
-            "version": "0.22.4",
-            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
-            "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "node-addon-api": "^8.3.0",
-                "node-gyp-build": "^4.8.4"
-            }
-        },
         "node_modules/@swagger-api/apidom-reference": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.6.0.tgz",
-            "integrity": "sha512-gYTDfWQM1heqrCCrCsZH+EWDyAkIGqEJnSJcVWKngwOkXJKeUwat8p1TOW4q3rkaTT+fBaYbrjTr9SkFtVbdMg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.1.tgz",
+            "integrity": "sha512-wxsRo12YVc2Q4o81K9EGzX5oM1htNDkeCIRkLyg1wPvzFQUH4khd6aOWYaX/0V0L+7yqwwmeW/t80xV8qLEGAQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.26.10",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.1",
+                "@swagger-api/apidom-error": "^1.11.1",
                 "@types/ramda": "~0.30.0",
-                "axios": "^1.12.2",
+                "axios": "^1.16.0",
                 "minimatch": "^10.2.1",
                 "ramda": "~0.30.0",
                 "ramda-adjunct": "^5.0.0"
             },
             "optionalDependencies": {
-                "@swagger-api/apidom-json-pointer": "^1.6.0",
-                "@swagger-api/apidom-ns-arazzo-1": "^1.6.0",
-                "@swagger-api/apidom-ns-asyncapi-2": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-2": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-0": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-json": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.6.0",
-                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.6.0"
+                "@swagger-api/apidom-json-pointer": "^1.11.1",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.1",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.1",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.1",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.1"
             }
         },
         "node_modules/@swagger-api/apidom-reference/node_modules/balanced-match": {
@@ -1871,9 +1852,9 @@
             }
         },
         "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -1883,12 +1864,12 @@
             }
         },
         "node_modules/@swagger-api/apidom-reference/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -2226,8 +2207,7 @@
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
             "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/markdown-it": {
             "version": "14.1.2",
@@ -2246,8 +2226,7 @@
             "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
             "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/prismjs": {
             "version": "1.26.5",
@@ -2282,6 +2261,17 @@
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
             "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
             "license": "MIT"
+        },
+        "node_modules/@upsetjs/venn.js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+            "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "d3-selection": "^3.0.0",
+                "d3-transition": "^3.0.1"
+            }
         },
         "node_modules/@xml-tools/parser": {
             "version": "1.0.11",
@@ -2326,19 +2316,10 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/ansi-escapes": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
-            "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2392,9 +2373,9 @@
             }
         },
         "node_modules/anymatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2415,49 +2396,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
-        },
-        "node_modules/array-differ": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha512-LeZY+DZDRnvP7eMuQ6LHfCzUGxAAIViUBliK24P3hWXL6y4SortgR6Nim6xrkfSLlmH0+k+9NYNwVC2s53ZrYQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-uniq": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/array-uniq": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/arrify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/asap": {
             "version": "2.0.6",
@@ -2497,14 +2435,40 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/axios/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/balanced-match": {
@@ -2599,9 +2563,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2807,14 +2771,14 @@
             }
         },
         "node_modules/cli-truncate": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-            "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+            "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "slice-ansi": "^7.1.0",
-                "string-width": "^8.0.0"
+                "slice-ansi": "^8.0.0",
+                "string-width": "^8.2.0"
             },
             "engines": {
                 "node": ">=20"
@@ -2866,13 +2830,6 @@
                 "simple-swizzle": "^0.2.2"
             }
         },
-        "node_modules/colorette": {
-            "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2893,16 +2850,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/commander": {
-            "version": "14.0.2",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-            "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
             }
         },
         "node_modules/concat-map": {
@@ -2929,9 +2876,9 @@
             }
         },
         "node_modules/core-js-pure": {
-            "version": "3.48.0",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-            "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+            "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
             "hasInstallScript": true,
             "license": "MIT",
             "funding": {
@@ -2950,13 +2897,13 @@
             }
         },
         "node_modules/css-tree": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-            "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "license": "MIT",
             "dependencies": {
-                "mdn-data": "2.12.2",
-                "source-map-js": "^1.0.1"
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -2968,26 +2915,13 @@
             "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
             "license": "MIT"
         },
-        "node_modules/cssstyle": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.5.tgz",
-            "integrity": "sha512-GlsEptulso7Jg0VaOZ8BXQi3AkYM5BOJKEO/rjMidSCq70FkIC5y0eawrCXeYzxgt3OCf4Ls+eoxN+/05vN0Ag==",
-            "license": "MIT",
-            "dependencies": {
-                "@asamuzakjp/css-color": "^4.1.1",
-                "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-                "css-tree": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
         "node_modules/cytoscape": {
             "version": "3.33.1",
             "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
             "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -3265,9 +3199,9 @@
             }
         },
         "node_modules/d3-format": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-            "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -3432,6 +3366,7 @@
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -3523,9 +3458,9 @@
             }
         },
         "node_modules/dagre-d3-es": {
-            "version": "7.0.13",
-            "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.13.tgz",
-            "integrity": "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==",
+            "version": "7.0.14",
+            "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+            "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3534,16 +3469,16 @@
             }
         },
         "node_modules/data-urls": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
-            "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
             "license": "MIT",
             "dependencies": {
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^15.0.0"
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/dayjs": {
@@ -3625,9 +3560,9 @@
             }
         },
         "node_modules/delaunator": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-            "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+            "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3728,14 +3663,10 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-            "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
-            "dev": true,
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+            "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
             "license": "(MPL-2.0 OR Apache-2.0)",
-            "engines": {
-                "node": ">=20"
-            },
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -3812,6 +3743,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
             "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -3891,6 +3823,17 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-toolkit": {
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+            "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
+        },
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -3956,9 +3899,9 @@
             }
         },
         "node_modules/eventemitter3": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "dev": true,
             "license": "MIT"
         },
@@ -4071,32 +4014,17 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/flat-cache": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "flatted": "^3.2.9",
-                "keyv": "^4.5.3",
-                "rimraf": "^3.0.2"
-            },
-            "engines": {
-                "node": "^10.12.0 || >=12.0.0"
-            }
-        },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -4183,13 +4111,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4215,9 +4136,9 @@
             }
         },
         "node_modules/get-east-asian-width": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-            "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4262,28 +4183,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/glob-parent": {
@@ -4464,15 +4363,15 @@
             "license": "CC0-1.0"
         },
         "node_modules/html-encoding-sniffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
             "license": "MIT",
             "dependencies": {
-                "whatwg-encoding": "^3.1.1"
+                "@exodus/bytes": "^1.6.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/htmlparser2": {
@@ -4539,32 +4438,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/husky": {
             "version": "9.1.7",
             "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -4585,6 +4458,7 @@
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
             "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4594,9 +4468,9 @@
             }
         },
         "node_modules/ics": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/ics/-/ics-3.8.1.tgz",
-            "integrity": "sha512-UqQlfkajfhrS4pUGQfGIJMYz/Jsl/ob3LqcfEhUmLbwumg+ZNkU0/6S734Vsjq3/FYNpEcZVKodLBoe+zBM69g==",
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/ics/-/ics-3.12.0.tgz",
+            "integrity": "sha512-BBPiZ/TbUyZrxui7SHKGOa/n2HUxaW9ucn7cw47NW9OSKe5tItYxIdN7Uczti5nKURmfwVvYi2aLigCJGH1+cA==",
             "license": "ISC",
             "dependencies": {
                 "nanoid": "^3.1.23",
@@ -4641,24 +4515,13 @@
             }
         },
         "node_modules/immutable": {
-            "version": "3.8.2",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-            "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+            "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
             }
         },
         "node_modules/inherits": {
@@ -4890,34 +4753,35 @@
             }
         },
         "node_modules/jsdom": {
-            "version": "27.3.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.3.0.tgz",
-            "integrity": "sha512-GtldT42B8+jefDUC4yUKAvsaOrH7PDHmZxZXNgF2xMmymjUbRYJvpAybZAKEmXDGTM0mCsz8duOa4vTm5AY2Kg==",
+            "version": "29.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
             "license": "MIT",
             "dependencies": {
-                "@acemir/cssom": "^0.9.28",
-                "@asamuzakjp/dom-selector": "^6.7.6",
-                "cssstyle": "^5.3.4",
-                "data-urls": "^6.0.0",
+                "@asamuzakjp/css-color": "^5.1.11",
+                "@asamuzakjp/dom-selector": "^7.1.1",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+                "@exodus/bytes": "^1.15.0",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
                 "decimal.js": "^10.6.0",
-                "html-encoding-sniffer": "^4.0.0",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.6",
+                "html-encoding-sniffer": "^6.0.0",
                 "is-potential-custom-element-name": "^1.0.1",
-                "parse5": "^8.0.0",
+                "lru-cache": "^11.3.5",
+                "parse5": "^8.0.1",
                 "saxes": "^6.0.0",
                 "symbol-tree": "^3.2.4",
-                "tough-cookie": "^6.0.0",
+                "tough-cookie": "^6.0.1",
+                "undici": "^7.25.0",
                 "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^8.0.0",
-                "whatwg-encoding": "^3.1.1",
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^15.1.0",
-                "ws": "^8.18.3",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.1",
                 "xml-name-validator": "^5.0.0"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
             },
             "peerDependencies": {
                 "canvas": "^3.0.0"
@@ -4927,13 +4791,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/json-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/junk": {
             "version": "3.1.0",
@@ -4973,23 +4830,13 @@
             }
         },
         "node_modules/keycloak-js": {
-            "version": "26.2.2",
-            "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.2.tgz",
-            "integrity": "sha512-ug7pNZ1xNkd7PPkerOJCEU2VnUhS7CYStDOCFJgqCNQ64h53ppxaKrh4iXH0xM8hFu5b1W6e6lsyYWqBMvaQFg==",
+            "version": "26.2.4",
+            "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.4.tgz",
+            "integrity": "sha512-PnXpR3ubETGOt0B/Qt2lxmPbkZr5bc3vlQsOqDoTPPQsZRp7JjhTKxlJ187uWh8qJhvBab6Gsjb06a8ayOPfuw==",
             "license": "Apache-2.0",
             "workspaces": [
                 "test"
             ]
-        },
-        "node_modules/keyv": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "json-buffer": "3.0.1"
-            }
         },
         "node_modules/khroma": {
             "version": "2.1.0",
@@ -5017,52 +4864,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/langium": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
-            "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chevrotain": "~11.1.1",
-                "chevrotain-allstar": "~0.3.1",
-                "vscode-languageserver": "~9.0.1",
-                "vscode-languageserver-textdocument": "~1.0.11",
-                "vscode-uri": "~3.1.0"
-            },
-            "engines": {
-                "node": ">=20.10.0",
-                "npm": ">=10.2.3"
-            }
-        },
-        "node_modules/langium/node_modules/chevrotain": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
-            "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/cst-dts-gen": "11.1.2",
-                "@chevrotain/gast": "11.1.2",
-                "@chevrotain/regexp-to-ast": "11.1.2",
-                "@chevrotain/types": "11.1.2",
-                "@chevrotain/utils": "11.1.2",
-                "lodash-es": "4.17.23"
-            }
-        },
-        "node_modules/langium/node_modules/chevrotain-allstar": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-            "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lodash-es": "^4.17.21"
-            },
-            "peerDependencies": {
-                "chevrotain": "^11.0.0"
-            }
-        },
         "node_modules/layout-base": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
@@ -5081,34 +4882,34 @@
             }
         },
         "node_modules/lint-staged": {
-            "version": "16.2.7",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
-            "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+            "version": "17.0.7",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz",
+            "integrity": "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "commander": "^14.0.2",
-                "listr2": "^9.0.5",
-                "micromatch": "^4.0.8",
-                "nano-spawn": "^2.0.0",
-                "pidtree": "^0.6.0",
+                "listr2": "^10.2.1",
+                "picomatch": "^4.0.4",
                 "string-argv": "^0.3.2",
-                "yaml": "^2.8.1"
+                "tinyexec": "^1.2.4"
             },
             "bin": {
                 "lint-staged": "bin/lint-staged.js"
             },
             "engines": {
-                "node": ">=20.17"
+                "node": ">=22.22.1"
             },
             "funding": {
                 "url": "https://opencollective.com/lint-staged"
+            },
+            "optionalDependencies": {
+                "yaml": "^2.9.0"
             }
         },
         "node_modules/liquidjs": {
-            "version": "10.24.0",
-            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.24.0.tgz",
-            "integrity": "sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==",
+            "version": "10.27.0",
+            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
+            "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5144,33 +4945,32 @@
             "license": "MIT"
         },
         "node_modules/listr2": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-            "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+            "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cli-truncate": "^5.0.0",
-                "colorette": "^2.0.20",
-                "eventemitter3": "^5.0.1",
+                "cli-truncate": "^5.2.0",
+                "eventemitter3": "^5.0.4",
                 "log-update": "^6.1.0",
                 "rfdc": "^1.4.1",
-                "wrap-ansi": "^9.0.0"
+                "wrap-ansi": "^10.0.0"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.13.0"
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "dev": true,
             "license": "MIT"
         },
@@ -5207,6 +5007,59 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/log-update/node_modules/slice-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/log-update/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update/node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5234,9 +5087,9 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "11.2.4",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -5257,6 +5110,7 @@
             "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -5281,9 +5135,9 @@
             }
         },
         "node_modules/markdown-it-attrs": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.3.1.tgz",
-            "integrity": "sha512-/ko6cba+H6gdZ0DOw7BbNMZtfuJTRp9g/IrGIuz8lYc/EfnmWRpaR3CFPnNbVz0LDvF8Gf1hFGPqrQqq7De0rg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-5.0.0.tgz",
+            "integrity": "sha512-7Wvp3Fc1YsHsj1oRKli1DGAMyGhozldtU99wEl4plc6OBsv1WZB+zT3Lgm1/49rVMvXWiYXbUU8rz3X6VVGKaQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5335,26 +5189,10 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/maximatch": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
-            "integrity": "sha512-9ORVtDUFk4u/NFfo0vG/ND/z7UQCVZBL539YW0+U1I7H1BkZwizcPx5foFv7LCPcBnm2U6RjFnQOsIvN4/Vm2A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-differ": "^1.0.0",
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "minimatch": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/mdn-data": {
-            "version": "2.12.2",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-            "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "license": "CC0-1.0"
         },
         "node_modules/mdurl": {
@@ -5365,59 +5203,33 @@
             "license": "MIT"
         },
         "node_modules/mermaid": {
-            "version": "11.12.3",
-            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.12.3.tgz",
-            "integrity": "sha512-wN5ZSgJQIC+CHJut9xaKWsknLxaFBwCPwPkGTSUYrTiHORWvpT8RxGk849HPnpUAQ+/9BPRqYb80jTpearrHzQ==",
+            "version": "11.15.0",
+            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+            "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@braintree/sanitize-url": "^7.1.1",
-                "@iconify/utils": "^3.0.1",
-                "@mermaid-js/parser": "^1.0.0",
+                "@iconify/utils": "^3.0.2",
+                "@mermaid-js/parser": "^1.1.1",
                 "@types/d3": "^7.4.3",
-                "cytoscape": "^3.29.3",
+                "@upsetjs/venn.js": "^2.0.0",
+                "cytoscape": "^3.33.1",
                 "cytoscape-cose-bilkent": "^4.1.0",
                 "cytoscape-fcose": "^2.2.0",
                 "d3": "^7.9.0",
                 "d3-sankey": "^0.12.3",
-                "dagre-d3-es": "7.0.13",
-                "dayjs": "^1.11.18",
-                "dompurify": "^3.2.5",
-                "katex": "^0.16.22",
+                "dagre-d3-es": "7.0.14",
+                "dayjs": "^1.11.19",
+                "dompurify": "^3.3.1",
+                "es-toolkit": "^1.45.1",
+                "katex": "^0.16.25",
                 "khroma": "^2.1.0",
-                "lodash-es": "^4.17.23",
-                "marked": "^16.2.1",
+                "marked": "^16.3.0",
                 "roughjs": "^4.6.6",
                 "stylis": "^4.3.6",
                 "ts-dedent": "^2.2.0",
-                "uuid": "^11.1.0"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
+                "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
             }
         },
         "node_modules/mime": {
@@ -5551,19 +5363,6 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
-        "node_modules/nano-spawn": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-            "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.17"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-            }
-        },
         "node_modules/nanoid": {
             "version": "3.3.11",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -5598,96 +5397,13 @@
             "license": "MIT"
         },
         "node_modules/node-addon-api": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
-            "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+            "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
             "license": "MIT",
             "optional": true,
             "engines": {
                 "node": "^18 || ^20 || >= 21"
-            }
-        },
-        "node_modules/node-domexception": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-            "deprecated": "Use your platform's native DOMException instead",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "github",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.5.0"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/node-fetch-commonjs": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.3.2.tgz",
-            "integrity": "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A==",
-            "license": "MIT",
-            "dependencies": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
-            }
-        },
-        "node_modules/node-fetch/node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/node-fetch/node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true,
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/node-fetch/node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/node-gyp-build": {
@@ -5780,16 +5496,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
             }
         },
         "node_modules/onetime": {
@@ -5887,21 +5593,22 @@
             "license": "MIT"
         },
         "node_modules/pagefind": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
-            "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+            "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "pagefind": "lib/runner/bin.cjs"
             },
             "optionalDependencies": {
-                "@pagefind/darwin-arm64": "1.4.0",
-                "@pagefind/darwin-x64": "1.4.0",
-                "@pagefind/freebsd-x64": "1.4.0",
-                "@pagefind/linux-arm64": "1.4.0",
-                "@pagefind/linux-x64": "1.4.0",
-                "@pagefind/windows-x64": "1.4.0"
+                "@pagefind/darwin-arm64": "1.5.2",
+                "@pagefind/darwin-x64": "1.5.2",
+                "@pagefind/freebsd-x64": "1.5.2",
+                "@pagefind/linux-arm64": "1.5.2",
+                "@pagefind/linux-x64": "1.5.2",
+                "@pagefind/windows-arm64": "1.5.2",
+                "@pagefind/windows-x64": "1.5.2"
             }
         },
         "node_modules/parse-entities": {
@@ -5937,15 +5644,27 @@
             "license": "MIT"
         },
         "node_modules/parse5": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-            "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
             "license": "MIT",
             "dependencies": {
-                "entities": "^6.0.0"
+                "entities": "^8.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/parseurl": {
@@ -5965,16 +5684,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/pathe": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5983,29 +5692,17 @@
             "license": "MIT"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/pidtree": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-            "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "pidtree": "bin/pidtree.js"
-            },
-            "engines": {
-                "node": ">=0.10"
             }
         },
         "node_modules/pkg-types": {
@@ -6063,6 +5760,7 @@
             "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "posthtml-parser": "^0.11.0",
                 "posthtml-render": "^3.0.0"
@@ -6111,11 +5809,12 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.7.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-            "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -6163,10 +5862,13 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/prr": {
             "version": "1.0.1",
@@ -6215,6 +5917,7 @@
             "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
             "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/ramda"
@@ -6382,9 +6085,9 @@
             }
         },
         "node_modules/readdirp/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6398,7 +6101,8 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/redux-immutable": {
             "version": "4.0.0",
@@ -6520,27 +6224,10 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/robust-predicates": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-            "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+            "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
             "dev": true,
             "license": "Unlicense"
         },
@@ -6594,6 +6281,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/saxes": {
@@ -6629,9 +6317,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -6818,26 +6506,26 @@
             }
         },
         "node_modules/slice-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-            "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+            "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "is-fullwidth-code-point": "^5.0.0"
+                "ansi-styles": "^6.2.3",
+                "is-fullwidth-code-point": "^5.1.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
         "node_modules/slugify": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-            "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+            "version": "1.6.9",
+            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+            "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6903,14 +6591,14 @@
             }
         },
         "node_modules/string-width": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-            "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "get-east-asian-width": "^1.3.0",
-                "strip-ansi": "^7.1.0"
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
             },
             "engines": {
                 "node": ">=20"
@@ -6920,13 +6608,13 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
                 "node": ">=12"
@@ -6965,36 +6653,38 @@
             }
         },
         "node_modules/swagger-client": {
-            "version": "3.37.0",
-            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.0.tgz",
-            "integrity": "sha512-pzU+B+DkUbrSwlj4/E8sGeP1w84/CFgDJAt80fHu650TxnOHbqFLGQjiE6luvpRxTPdfK2zRHJP7I6CgUkI8yA==",
+            "version": "3.37.4",
+            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.4.tgz",
+            "integrity": "sha512-3xxqc9s99Vsf47ket2j7D4Tw6b6T7ObNvTqSP009yBeoAo0fy0yprqOVxFISTrvRxN7jgfrEi8GXMhsjzb1M0g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.22.15",
                 "@scarf/scarf": "=1.4.0",
-                "@swagger-api/apidom-core": "^1.6.0",
-                "@swagger-api/apidom-error": "^1.6.0",
-                "@swagger-api/apidom-json-pointer": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-1": "^1.6.0",
-                "@swagger-api/apidom-ns-openapi-3-2": "^1.6.0",
-                "@swagger-api/apidom-reference": "^1.6.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-reference": "^1.11.0",
                 "@swaggerexpert/cookie": "^2.0.2",
                 "deepmerge": "~4.3.0",
                 "fast-json-patch": "^3.0.0-1",
                 "js-yaml": "^4.1.0",
                 "neotraverse": "=0.6.18",
                 "node-abort-controller": "^3.1.1",
-                "node-fetch-commonjs": "^3.3.2",
                 "openapi-path-templating": "^2.2.1",
                 "openapi-server-url-templating": "^1.3.0",
                 "ramda": "^0.30.1",
                 "ramda-adjunct": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/swagger-ui": {
-            "version": "5.32.0",
-            "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.32.0.tgz",
-            "integrity": "sha512-9J2sJUqUJ/2qSLjMxWLf2tnEEWjSd7/0/6IJpzCBpgyQ+WpXGuVQn6K2RqGTrehU8IijOepvcyVLMDqrjEoOvA==",
+            "version": "5.32.6",
+            "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.32.6.tgz",
+            "integrity": "sha512-Kju+1XSjjnzm6X9JBW4eRXX8+5NIxELDagrzRh5BnvnWu91+6aA7IpAlVqLVfJrKYkY7w4+NIfD+ad18tGqyGQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime-corejs3": "^7.27.1",
@@ -7004,12 +6694,12 @@
                 "classnames": "^2.5.1",
                 "css.escape": "1.5.1",
                 "deep-extend": "0.6.0",
-                "dompurify": "=3.2.6",
+                "dompurify": "^3.4.0",
                 "ieee754": "^1.2.1",
                 "immutable": "^3.x.x",
                 "js-file-download": "^0.4.12",
                 "js-yaml": "=4.1.1",
-                "lodash": "^4.17.21",
+                "lodash": "^4.18.1",
                 "prop-types": "^15.8.1",
                 "randexp": "^0.5.3",
                 "randombytes": "^2.1.0",
@@ -7028,20 +6718,11 @@
                 "reselect": "^5.1.1",
                 "serialize-error": "^8.1.0",
                 "sha.js": "^2.4.12",
-                "swagger-client": "^3.37.0",
+                "swagger-client": "^3.37.4",
                 "url-parse": "^1.5.10",
                 "xml": "=1.0.1",
                 "xml-but-prettier": "^1.0.1",
                 "zenscroll": "^4.0.2"
-            }
-        },
-        "node_modules/swagger-ui/node_modules/dompurify": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
-            "license": "(MPL-2.0 OR Apache-2.0)",
-            "optionalDependencies": {
-                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/swagger-ui/node_modules/react": {
@@ -7049,6 +6730,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7058,6 +6740,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -7104,9 +6787,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-            "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7131,21 +6814,21 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.0.19",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
-            "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+            "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.19"
+                "tldts-core": "^7.4.2"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.0.19",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
-            "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+            "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
             "license": "MIT"
         },
         "node_modules/to-buffer": {
@@ -7198,9 +6881,9 @@
             "license": "MIT"
         },
         "node_modules/tough-cookie": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-            "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tldts": "^7.0.5"
@@ -7219,18 +6902,6 @@
             },
             "engines": {
                 "node": ">=20"
-            }
-        },
-        "node_modules/tree-sitter": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
-            "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "node-addon-api": "^8.0.0",
-                "node-gyp-build": "^4.8.0"
             }
         },
         "node_modules/tree-sitter-json": {
@@ -7330,6 +7001,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/undici": {
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+            "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -7373,9 +7053,9 @@
             }
         },
         "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/broofa",
@@ -7383,63 +7063,8 @@
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/esm/bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
-        },
-        "node_modules/vscode-jsonrpc": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/vscode-languageserver": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-            "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "vscode-languageserver-protocol": "3.17.5"
-            },
-            "bin": {
-                "installServerIntoExtension": "bin/installServerIntoExtension"
-            }
-        },
-        "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "vscode-jsonrpc": "8.2.0",
-                "vscode-languageserver-types": "3.17.5"
-            }
-        },
-        "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/vscode-languageserver-types": {
-            "version": "3.17.5",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/vscode-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-            "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",
@@ -7453,15 +7078,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/web-tree-sitter": {
             "version": "0.24.5",
             "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.5.tgz",
@@ -7470,46 +7086,35 @@
             "optional": true
         },
         "node_modules/webidl-conversions": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
-            "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=20"
             }
         },
-        "node_modules/whatwg-encoding": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-            "license": "MIT",
-            "dependencies": {
-                "iconv-lite": "0.6.3"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/whatwg-mimetype": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/whatwg-url": {
-            "version": "15.1.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
-            "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
             "license": "MIT",
             "dependencies": {
+                "@exodus/bytes": "^1.11.0",
                 "tr46": "^6.0.0",
-                "webidl-conversions": "^8.0.0"
+                "webidl-conversions": "^8.0.1"
             },
             "engines": {
-                "node": ">=20"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/which-typed-array": {
@@ -7534,52 +7139,28 @@
             }
         },
         "node_modules/wrap-ansi": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+            "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
+                "ansi-styles": "^6.2.3",
+                "string-width": "^8.2.0",
+                "strip-ansi": "^7.1.2"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -7628,11 +7209,12 @@
             "license": "MIT"
         },
         "node_modules/yaml": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "dev": true,
             "license": "ISC",
+            "optional": true,
             "bin": {
                 "yaml": "bin.mjs"
             },

--- a/package.json
+++ b/package.json
@@ -28,31 +28,31 @@
         "node": ">=24.0.0"
     },
     "devDependencies": {
-        "@11ty/eleventy": "^3.0.0",
-        "@11ty/eleventy-img": "^5.0.0",
-        "@11ty/eleventy-navigation": "^0.3.5",
+        "@11ty/eleventy": "^3.1.5",
+        "@11ty/eleventy-img": "^6.0.4",
+        "@11ty/eleventy-navigation": "^1.0.5",
         "@11ty/eleventy-plugin-bundle": "^3.0.0",
         "@11ty/eleventy-plugin-rss": "^2.0.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
-        "@gouvfr/dsfr": "^1.14.3",
+        "@gouvfr/dsfr": "^1.14.4",
         "@prettier/plugin-xml": "^3.4.2",
         "chalk": "^5.0.0",
         "husky": "^9.0.11",
-        "ics": "^3.8.1",
-        "lint-staged": "^16.0.0",
+        "ics": "^3.12.0",
+        "lint-staged": "^17.0.7",
         "luxon": "^3.5.0",
         "markdown-it-anchor": "^9.0.0",
-        "markdown-it-attrs": "^4.2.0",
+        "markdown-it-attrs": "^5.0.0",
         "markdown-it-container": "^4.0.0",
         "mermaid": "^11.0.0",
-        "pagefind": "^1.4.0",
-        "prettier": "^3.7.4"
+        "pagefind": "^1.5.0",
+        "prettier": "^3.8.3"
     },
     "dependencies": {
         "@codegouvfr/eleventy-plugin-calendar": "^3.0.5",
         "@codegouvfr/eleventy-plugin-i18n": "^0.1.3",
-        "jsdom": "^27.0.0",
-        "keycloak-js": "^26.2.2",
+        "jsdom": "^29.1.1",
+        "keycloak-js": "^26.2.4",
         "swagger-ui": "^5.31.0"
     },
     "lint-staged": {

--- a/public/js/search-results.js
+++ b/public/js/search-results.js
@@ -314,6 +314,12 @@ class PageFinder {
 (async () => {
     const pagefind = await import(PAGEFIND_URL);
 
+    await pagefind.options({
+        ranking: {
+            diacriticSimilarity: 0,
+        },
+    });
+
     // affichage des premiers résultats
     const pageFinder = new PageFinder(pagefind);
 


### PR DESCRIPTION
Avec la montée de version de `pagefind`, j'ai mis le paramètre `diacriticSimilarity: 0`, ce qui signifie que le résultat d'une recherche sera identique avec ou sans accent. 
Si on veut tout de même favoriser les résultats avec accents similaires, il faut augmenter la valeur (ou même enlever la configuration, la valeur sera de 0.8 par défaut). 

J'ai également fait la montée de version de  toute les dépendances sauf `@11ty/eleventy-plugin-rss`. Si j'ai bien compris, il faudrait passer en ESM pour que celle-ci fonctionne. Est-ce que je me lance dans le refactoring ?