### PR TITLE
fix : lien absolu vers le flux RSS des alertes #330

### DIFF
--- a/content/fr/niveau-de-service.njk
+++ b/content/fr/niveau-de-service.njk
@@ -16,7 +16,7 @@ eleventyNavigation:
     <h2>Alertes, incidents et maintenances programmées</h2>
   </div>
 <div class="fr-col-12 fr-col-xl-4 text-right-xl">
-  <a href="/rss/alertes" target="_blank" rel="noreferrer" title="Suivre les alertes par RSS - ouvre une nouvelle fenêtre" id="fr-button-:r2m:" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-mb-2w" data-fr-js-button-actionee="true">Suivre par RSS</a>
+  <a href="https://cartes.gouv.fr/rss/alertes" target="_blank" rel="noreferrer" title="Suivre les alertes par RSS - ouvre une nouvelle fenêtre" id="fr-button-:r2m:" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-mb-2w" data-fr-js-button-actionee="true">Suivre par RSS</a>
 </div>
 </div>
 <div id="service-alert" class="fr-mb-2w">


### PR DESCRIPTION
Lors du changement de dépôt, j'avais oublié de passer le lien en absolu.