### PR TITLE
Ajout des compléments de doc sur le tutot alimentation-diffusion-vecteur

### DIFF
--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/gestion-statique.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/gestion-statique.md
@@ -14,6 +14,14 @@ Pour certains types de diffusion, le serveur de diffusion peut avoir besoin de f
 
 ### Génération d’un SLD
 
+:::info
+De manière générale il faut retenir que la Géoplateforme consomme des SLD dans leur version 1.0.0.
+
+Vous devez être vigilant à la version du SLD dont vous disposez ou celle générée par votre client SIG préféré. Par exemple QGIS génère du SLD 1.1.0
+:::
+
+Différentes options existent pour générer un SLD compatible : 
+
 Après l’export des styles depuis QGIS dans son format, il est nécessaire d’utiliser l’outil GeoStyler en ligne de commande pour les convertir :
 
 ```bash
@@ -23,9 +31,23 @@ $  geostyler-cli -o pays.sld -t sld -s qgis pays.qml
 ✔ File "pays.qml" translated successfully. Output written to pays.sld
 ```
 
+Vous pouvez, toujours depuis QGIS, exporter directement un SLD version 1.1.0 et utiliser le démonstrateur en ligne de Geostyler pour en faire un SLD 1.0.0 : https://demo.geostyler.org/ 
+
 :::warning
 Chaque outil d’export peut entraîner des comportements différents. Au final, le SLD sera interprété par GeoServer sur la Géoplateforme. Le plugin [GeoCat Bridge](https://plugins.qgis.org/plugins/geocatbridge/) peut également être utilisé.
 :::
+
+:::warning
+De manière générale il est recommandé d'être particulièrement attentif avec les SLD référençant des pictogrammes ou des motifs de remplissage.
+
+En effet vous devrez prévoir :
+- d'héberger le pictogramme sur la Géoplateforme en tant qu'annexe [Voir le tutoriel](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/gestion-des-donnees-complementaires/gestion-des-annexes/)
+- de modifier manuellement votre SLD pour pointer sur le pictogramme hébergé en annexe. 
+
+Vous êtes invités à privilégier des pictogrammes images (jpeg ou png) et à éviter les trames complexes.
+
+:::
+
 
 {{ component("download", {
     title: "ecoregions.sld",

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/gestion-statique.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/gestion-statique.md
@@ -17,10 +17,10 @@ Pour certains types de diffusion, le serveur de diffusion peut avoir besoin de f
 :::info
 De manière générale il faut retenir que la Géoplateforme consomme des SLD dans leur version 1.0.0.
 
-Vous devez être vigilant à la version du SLD dont vous disposez ou celle générée par votre client SIG préféré. Par exemple QGIS génère du SLD 1.1.0
+Vous devez être vigilant à la version du SLD dont vous disposez ou celle générée par votre client SIG préféré. Par exemple QGIS génère du SLD 1.1.0.
 :::
 
-Différentes options existent pour générer un SLD compatible : 
+Différentes options existent pour générer un SLD compatible :
 
 Après l’export des styles depuis QGIS dans son format, il est nécessaire d’utiliser l’outil GeoStyler en ligne de commande pour les convertir :
 
@@ -31,23 +31,21 @@ $  geostyler-cli -o pays.sld -t sld -s qgis pays.qml
 ✔ File "pays.qml" translated successfully. Output written to pays.sld
 ```
 
-Vous pouvez, toujours depuis QGIS, exporter directement un SLD version 1.1.0 et utiliser le démonstrateur en ligne de Geostyler pour en faire un SLD 1.0.0 : https://demo.geostyler.org/ 
+Vous pouvez, toujours depuis QGIS, exporter directement un SLD version 1.1.0 et utiliser le démonstrateur en ligne de GeoStyler pour en faire un SLD 1.0.0 : [https://demo.geostyler.org/](https://demo.geostyler.org/)
 
 :::warning
 Chaque outil d’export peut entraîner des comportements différents. Au final, le SLD sera interprété par GeoServer sur la Géoplateforme. Le plugin [GeoCat Bridge](https://plugins.qgis.org/plugins/geocatbridge/) peut également être utilisé.
 :::
 
 :::warning
-De manière générale il est recommandé d'être particulièrement attentif avec les SLD référençant des pictogrammes ou des motifs de remplissage.
+De manière générale il est recommandé d’être particulièrement attentif avec les SLD référençant des pictogrammes ou des motifs de remplissage.
 
-En effet vous devrez prévoir :
-- d'héberger le pictogramme sur la Géoplateforme en tant qu'annexe [Voir le tutoriel](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/gestion-des-donnees-complementaires/gestion-des-annexes/)
-- de modifier manuellement votre SLD pour pointer sur le pictogramme hébergé en annexe. 
+En effet vous devrez prévoir :
+- d’héberger le pictogramme sur la Géoplateforme en tant qu’annexe : [voir le tutoriel](../../../gestion-des-donnees-complementaires/gestion-des-annexes/)
+- de modifier manuellement votre SLD pour pointer sur le pictogramme hébergé en annexe
 
-Vous êtes invités à privilégier des pictogrammes images (jpeg ou png) et à éviter les trames complexes.
-
+Vous êtes invités à privilégier des pictogrammes images (JPEG ou PNG) et à éviter les trames complexes.
 :::
-
 
 {{ component("download", {
     title: "ecoregions.sld",
@@ -188,7 +186,6 @@ On dépose les 4 fichiers de configuration (2 SLD et 2 FTL).
         ["name = FTL pour les pays"]
     ]
 }) }}
-
 ??? Corps de réponse JSON
 ```json
 {

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/integration.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/integration.md
@@ -167,40 +167,34 @@ On distingue le traitement, ressource de la plateforme mise à disposition de l�
 }
 ```
 ???
-??? Plus d'aide sur la configuration de l'exécution du traitement d'intégration vecteur
+??? Plus d’aide sur la configuration de l’exécution du traitement d’intégration vecteur
+Description des paramètres en entrée :
+- `inputs`/`upload` : Il s’agit ici d’une liste (présence des caractères « `[ ]` ») qui prend comme valeur au moins un identifiant entrepôt de **livraison** (voir étape précédente).
+- `output`/`stored_data`/`name` : Le nom défini ici est un nommage libre.
 
-- Description des paramètres en entrée :
-    - **_inputs/upload_** :  Il s'agit ici d'une liste (présence des caractères [ ]) qui prend comme valeur au moins un identifiant entrepôt de **livraison** (voir étape précédente)
-    - **_output/stored_data/name_** : Le nom définit ici est un nommage libre.
+    **Cette information n’est lisible que par un autre utilisateur membre de cet entrepôt, pas par l’utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour vous - producteur de donnée.**
 
-        **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** 
+    Cette information est modifiable après coup.
+- `output`/`stored_data`/`storage_tags` : Il s’agit ici d’une liste (présence des caractères « `[ ]` ») qui prend comme valeur au moins un tag associé au stockage qui va accueillir la donnée de sortie.
 
-        Cette information est modifiable après coup.
+    Vous pouvez retrouver ces tags via la route `GET /datastores/{datastore}/storages` (rubrique « Entrepôt » du swagger) dans l’attribut de réponse `labels` associé à chaque stockage.
 
-    - **_output/stored_data/storage_tags_** : Il s'agit ici d'une liste (présence des caractères [ ]) qui prend comme valeur au moins un tag associé au stockage qui va accueillir la donnée de sortie. 
-
-        Vous pouvez retrouvez ces tags via la route GET /datastores/{datastore}/storages (rubrique Entrepôt du Swagger) dans l'attribut de réponse "labels" associé à chaque stockage. 
-
-        Pour une donnée vecteur en entrée, seul le stockage PostgreSQL est accessible, ce qui correspond au label, donc au storage_tag "VECTEUR".
-    
-    - **_parameters/srs_** : ce paramètre optionnel permet de faire faire à la Géoplateforme une reprojection des données au moment de leur intégration. dans l'exemple du tutoriel : On livre une donnée en EPSG:4326 et ici avec le paramètre "srs" : "EPSG:3857", elle sera donc re-projetée par la Géoplateforme en projection Google Mercator et stockée sous cette projection.
+    Pour une donnée vecteur en entrée, seul le stockage PostgreSQL est accessible, ce qui correspond au label, donc au `storage_tag` : `VECTEUR`.
+- `parameters`/`srs` : ce paramètre optionnel permet de faire faire à la Géoplateforme une reprojection des données au moment de leur intégration. Dans l’exemple du tutoriel : on livre une donnée en EPSG:4326 et ici avec le paramètre `"srs": "EPSG:3857"`, elle sera donc re-projetée par la Géoplateforme en projection Google Mercator et stockée sous cette projection.
 
 :::info
-Comme pour la livraison il vous est possible de configurer l'envoi d'un mail automatique à la fin du traitement.
+Comme pour la livraison il vous est possible de configurer l’envoi d’un courriel automatique à la fin du traitement.
 
-Pour ce faire, il suffit d'ajouter l'élément json ci-dessous après l'élément "parameters" dans le corps de requête de déclaration d'exécution.
+Pour ce faire, il suffit d’ajouter l’élément JSON ci-dessous après l’élément `parameters` dans le corps de requête de déclaration d’exécution.
 ```json
 "callback": {
     "type": "email",
     "to_address": [
-      "example@mail.fr"
+        "example@mail.fr"
     ]
-  }
-
+}
 ```
-
 Vous êtes invités à vous référer au swagger pour avoir les détails et options complètes sur cette partie.
-
 :::
 ???
 ????
@@ -222,10 +216,10 @@ Les noms des tables et des champs sont « standardisés » lors de l’intégr
 #### Consultation de l’état de l’exécution
 
 Une exécution va avoir les statuts dans l’ordre suivant :
-- CREATED : créée mais non lancée
-- WAITING : lancée mais pas encore prise en charge par le <span lang="en">_cluster_</span> de calcul
-- PROGRESS : en cours d’exécution sur le <span lang="en">_cluster_</span> de calcul
-- SUCCESS ou FAILURE : terminé
+- `CREATED` : créée mais non lancée
+- `WAITING` : lancée mais pas encore prise en charge par le <span lang="en">_cluster_</span> de calcul
+- `PROGRESS` : en cours d’exécution sur le <span lang="en">_cluster_</span> de calcul
+- `SUCCESS` ou `FAILURE` : terminé
 
 <br>
 
@@ -331,27 +325,23 @@ Une exécution va avoir les statuts dans l’ordre suivant :
 }
 ```
 ???
-??? Plus d'aide sur l'identification de la donnée stockée de sortie
-
-Dès le lancement de l'exécution du traitement, dans le corps de réponse ou à chaque interrogation de la requête d'état d'exécution vous disposez dans le corps de réponse de ces requêtes de l'élément json :
-
+??? Plus d’aide sur l’identification de la donnée stockée de sortie
+Dès le lancement de l’exécution du traitement, dans le corps de réponse ou à chaque interrogation de la requête d’état d’exécution vous disposez dans le corps de réponse de ces requêtes de l’élément JSON :
 ```json
 "output": {
-        "stored_data": {
-            "name": "Pays et éco-régions",
-            "type": "VECTOR-DB",
-            "status": "GENERATING",
-            "_id": "{stored data}"
-        }
+    "stored_data": {
+        "name": "Pays et éco-régions",
+        "type": "VECTOR-DB",
+        "status": "GENERATING",
+        "_id": "{stored data}"
+    }
 }
 ```
-ce qui vous donne l'élément "_id" à isoler pour identifier ensuite votre stored_data de sortie
+Ce qui vous donne l’élément `_id` à isoler pour identifier ensuite votre `stored_data` de sortie.
 
 :::info
-La stored_data de sortie n'est exploitable et interrogeable qu'une fois l'exécution du traitement terminée avec succès.
+La `stored_data` de sortie n’est exploitable et interrogeable qu’une fois l’exécution du traitement terminée avec succès.
 :::
-
-
 ???
 ????
 <br>
@@ -367,7 +357,7 @@ Maintenant que la donnée a été stockée de manière pérenne, on peut supprim
 ???
 
 :::warning
-La livraison n'a qu'un rôle temporaire, le temps que les données soient transformées et stockées dans leur format pérenne sur la plateforme. Les fichiers déposés ne sont pas ceux utilisés par les services de diffusion.
+La livraison n’a qu’un rôle temporaire, le temps que les données soient transformées et stockées dans leur format pérenne sur la plateforme. Les fichiers déposés ne sont pas ceux utilisés par les services de diffusion.
 
-La livraison doit impérativement être supprimée après la réalisation des étapes "traitement".
+La livraison doit impérativement être supprimée après la réalisation des étapes « traitement ».
 :::

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/integration.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/integration.md
@@ -167,6 +167,42 @@ On distingue le traitement, ressource de la plateforme mise à disposition de l�
 }
 ```
 ???
+??? Plus d'aide sur la configuration de l'exécution du traitement d'intégration vecteur
+
+- Description des paramètres en entrée :
+    - **_inputs/upload_** :  Il s'agit ici d'une liste (présence des caractères [ ]) qui prend comme valeur au moins un identifiant entrepôt de **livraison** (voir étape précédente)
+    - **_output/stored_data/name_** : Le nom définit ici est un nommage libre.
+
+        **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** 
+
+        Cette information est modifiable après coup.
+
+    - **_output/stored_data/storage_tags_** : Il s'agit ici d'une liste (présence des caractères [ ]) qui prend comme valeur au moins un tag associé au stockage qui va accueillir la donnée de sortie. 
+
+        Vous pouvez retrouvez ces tags via la route GET /datastores/{datastore}/storages (rubrique Entrepôt du Swagger) dans l'attribut de réponse "labels" associé à chaque stockage. 
+
+        Pour une donnée vecteur en entrée, seul le stockage PostgreSQL est accessible, ce qui correspond au label, donc au storage_tag "VECTEUR".
+    
+    - **_parameters/srs_** : ce paramètre optionnel permet de faire faire à la Géoplateforme une reprojection des données au moment de leur intégration. dans l'exemple du tutoriel : On livre une donnée en EPSG:4326 et ici avec le paramètre "srs" : "EPSG:3857", elle sera donc re-projetée par la Géoplateforme en projection Google Mercator et stockée sous cette projection.
+
+:::info
+Comme pour la livraison il vous est possible de configurer l'envoi d'un mail automatique à la fin du traitement.
+
+Pour ce faire, il suffit d'ajouter l'élément json ci-dessous après l'élément "parameters" dans le corps de requête de déclaration d'exécution.
+```json
+"callback": {
+    "type": "email",
+    "to_address": [
+      "example@mail.fr"
+    ]
+  }
+
+```
+
+Vous êtes invités à vous référer au swagger pour avoir les détails et options complètes sur cette partie.
+
+:::
+???
 ????
 <br>
 
@@ -295,6 +331,28 @@ Une exécution va avoir les statuts dans l’ordre suivant :
 }
 ```
 ???
+??? Plus d'aide sur l'identification de la donnée stockée de sortie
+
+Dès le lancement de l'exécution du traitement, dans le corps de réponse ou à chaque interrogation de la requête d'état d'exécution vous disposez dans le corps de réponse de ces requêtes de l'élément json :
+
+```json
+"output": {
+        "stored_data": {
+            "name": "Pays et éco-régions",
+            "type": "VECTOR-DB",
+            "status": "GENERATING",
+            "_id": "{stored data}"
+        }
+}
+```
+ce qui vous donne l'élément "_id" à isoler pour identifier ensuite votre stored_data de sortie
+
+:::info
+La stored_data de sortie n'est exploitable et interrogeable qu'une fois l'exécution du traitement terminée avec succès.
+:::
+
+
+???
 ????
 <br>
 
@@ -307,3 +365,9 @@ Maintenant que la donnée a été stockée de manière pérenne, on peut supprim
 {{ urls.api_entrepot }}/datastores/{datastore}/uploads/{upload}
 ```
 ???
+
+:::warning
+La livraison n'a qu'un rôle temporaire, le temps que les données soient transformées et stockées dans leur format pérenne sur la plateforme. Les fichiers déposés ne sont pas ceux utilisés par les services de diffusion.
+
+La livraison doit impérativement être supprimée après la réalisation des étapes "traitement".
+:::

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/livraison.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/livraison.md
@@ -56,40 +56,31 @@ La livraison n’a qu’un rôle temporaire, le temps que les données soient tr
 }
 ```
 ???
-??? Plus d'aide sur la déclaration de la livraison
-- La livraison est une entité qui permet de déposer un ensemble de fichiers de données au sein de l'entrepôt. Une livraison et son contenu seront toujours utilisés comme un tout.
+??? Plus d’aide sur la déclaration de la livraison
+- La livraison est une entité qui permet de déposer un ensemble de fichiers de données au sein de l’entrepôt. Une livraison et son contenu seront toujours utilisés comme un tout.
+    :::warning
+    La livraison n’a qu’un rôle temporaire, le temps que les données soient transformées et stockées dans leur format pérenne sur la plateforme. Les fichiers déposés ne sont pas ceux utilisés par les services de diffusion.
+
+    La livraison doit impérativement être supprimée après la réalisation des étapes « traitement ».
+    :::
+- Dans la requête ci-dessus, `{datastore}` doit être remplacé par l’identifiant de votre datastore de travail.
+- Description des paramètres en entrée :
+    - `description` : Permet de décrire le contenu de la livraison en quelques mots. **Cette information n’est lisible que par un autre utilisateur membre de cet entrepôt, pas par l’utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour vous (producteur de donnée).** Cette information est modifiable après coup.
+    - `name` : Permet de nommer cette livraison. **Cette information n’est lisible que par un autre utilisateur membre de cet entrepôt, pas par l’utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour vous - producteur de donnée.** Cette information est modifiable après coup.
+    - `type` : Définit le type de la donnée qui va être livrée. Pour ce tutoriel la valeur sera exclusivement **`VECTOR`**. Cette information n’est pas modifiable après coup. En cas d’erreur vous devrez créer une nouvelle livraison.
+    - `srs` : Définit la projection des données **en entrée**. Cette projection ne préjuge pas de la projection de diffusion des données. Cette information n’est pas modifiable après coup. En cas d’erreur vous devrez créer une nouvelle livraison.
+- On retrouve en sortie, les paramètres et leurs valeurs saisis en entrée ainsi que quelques informations supplémentaires :
+    - `status` : Le statut de la livraison au sein de l’entrepôt. Elle est `OPEN` (ouverte) après création, ce qui correspond à un état compatible avec l’alimentation à venir de cette livraison.
+    - `contact` : L’adresse électronique de contact qui correspond à l’adresse électronique de contact associé à la communauté qui porte cette livraison.
+    - `size` : La taille **en octet** de cette livraison (pour le moment à `0` puisque la livraison n’a pas été alimentée).
+    - `last_event` : Mentionne la dernière action effectuée sur cette livraison et **le compte utilisateur ayant mené cette action**.
 
 :::warning
-La livraison n'a qu'un rôle temporaire, le temps que les données soient transformées et stockées dans leur format pérenne sur la plateforme. Les fichiers déposés ne sont pas ceux utilisés par les services de diffusion.
+**La seule information réellement essentielle** pour poursuivre l’action de livraison est reprise en fin de réponse :
 
-La livraison doit impérativement être supprimée après la réalisation des étapes "traitement".
+**`_id`** : C’est l’identifiant attribué par l’entrepôt Géoplateforme à la livraison. Cet identifiant doit être **obligatoirement récupéré en sortie de la création de la livraison pour être utilisé dans les prochains appels.**
 :::
 
-- Dans la requête ci-dessus, {datastore} doit être remplacé par l'identifiant de votre datastore de travail.
-
-- Description des paramètres en entrée :
-    - **_description_** : Permet de décrire le contenu de la livraison en quelques mots. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous (producteur de donnée).** Cette information est modifiable après coup.
-
-    - **_name_** : Permet de nommer cette livraison. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** Cette information est modifiable après coup.
-
-    - **_type_** : Définit le type de la donnée qui va être livrée. Pour ce tutoriel la valuer sera exclusivement **VECTOR**. Cette information n'est pas modifiable après coup. En cas d'erreur vous devrez créer une nouvelle livraison.
-
-    - **_srs_** : Définit la projection des données **en entrée**. Cette projection ne préjuge pas de la projection de diffusion des données. Cette information n'est pas modifiable après coup. En cas d'erreur vous devrez créer une nouvelle livraison.
-
-- On retrouve en sortie, les paramètres et leur valeurs saisis en entrée ainsi que quelques informations supplémentaires :
-    - **_status_** : Le statut de la livraison au sein de l'entrepôt. elle est OPEN (ouverte) après création, ce qui correspond à un état compatible avec l'alimentation à venir de cette livraison.
-
-    - **_contact_** : L'email de contact qui correspond à l'email de contact associé à la communauté qui porte cette livraison.
-
-    - **_size_** : La taille **en octet** de cette livraison (pour le moment à 0 puisque la livraison n'a pas été alimentée). 
-
-    - **_last_event_** : Mentionne la dernière action effectuée sur cette livraison et **le compte utilisateur ayant mené cette action**.
-
-:::warning
-**La seule information réellement essentielle** pour poursuivre l'action de livraison est reprise en fin de réponse : 
-        - **_id** : C'est l'identifiant attribué par l'entrepôt Géoplateforme à la livraison. Cet identifiant doit être **obligatoirement récupéré en sortie de la création de la livraison pour être utilisé dans les prochains appels.**
-:::
- 
 ???
 ????
 <br>
@@ -97,7 +88,7 @@ La livraison doit impérativement être supprimée après la réalisation des é
 #### Téléverser un fichier
 
 Les formats de fichier vecteur gérés sont :
-- Geopackage
+- GeoPackage
 - GeoJSON
 - Shapefile
 - CSV :
@@ -105,13 +96,13 @@ Les formats de fichier vecteur gérés sont :
     - si la donnée est ponctuelle et que les coordonnées sont dans deux colonnes, elles doivent avoir comme nom :
         - `lon`, `x`, `longitude`
         - `lat`, `y`, `latitude`
-- SQL. Les instructions autorisées sont les suivantes, sans préciser de nom de schéma :
-    - CREATE TABLE
-    - CREATE VIEW
-    - CREATE INDEX
-    - CREATE SEQUENCE
-    - ALTER TABLE
-    - ALTER SEQUENCE
+- SQL : Les instructions autorisées sont les suivantes, sans préciser de nom de schéma :
+    - `CREATE TABLE`
+    - `CREATE VIEW`
+    - `CREATE INDEX`
+    - `CREATE SEQUENCE`
+    - `ALTER TABLE`
+    - `ALTER SEQUENCE`
 - FlatGeoBuf (à venir)
 - Géoparquet (à venir)
 
@@ -129,27 +120,25 @@ Les formats de fichier vecteur gérés sont :
         ["file = &lt;monde.gpkg&gt;"]
     ]
 }) }}
-??? Plus d'aide sur le remplissage d'une livraison
+??? Plus d’aide sur le remplissage d’une livraison
 
 :::warning
-Dans le paramètre de requête "path" de la requête de remplissage, la valeur à indiquer correspond à l'arborescence de stockage **sur la Géoplateforme**, elle **ne correspond pas** à l'arborescence de stockage du fichier sur votre environnement.
+Dans le paramètre de requête `path` de la requête de remplissage, la valeur à indiquer correspond à l’arborescence de stockage **sur la Géoplateforme**, elle **ne correspond pas** à l’arborescence de stockage du fichier sur votre environnement.
 
-Le paramètre file est lui réservé à pointer vers le fichier là où il se trouve **sur votre environnement**.
+Le paramètre `file` est lui réservé à pointer vers le fichier là où il se trouve **sur votre environnement**.
 :::
 
 :::info
-Une requête de livraison ne prend qu'un seul fichier en entrée par requête. Si vous livrez un fichier SHP, vous devrez donc répéter la requête de livraison en adaptant la valeur de "path" et de "file" **pour chaque fichier composant le SHP**. Donc a minima un appel pour le .shp, un second pour le .shx et un troisième pour le .prj
+Une requête de livraison ne prend qu’un seul fichier en entrée par requête. Si vous livrez un fichier SHP, vous devrez donc répéter la requête de livraison en adaptant la valeur de `path` et de `file` **pour chaque fichier composant le SHP**. Donc a minima un appel pour le SHP, un second pour le SHX et un troisième pour le PRJ.
 :::
 
 :::info
-Une livraison est traitée comme un tout. Cela signifie qu'une livraison débouche sur la création d'une donnée stockée pérenne sur votre entrepôt. dans le cas d'une donnée vecteur, il faut comprendre cette notion comme un schéma de base de données PostgreSQL.
+Une livraison est traitée comme un tout. Cela signifie qu’une livraison débouche sur la création d’une donnée stockée pérenne sur votre entrepôt. Dans le cas d’une donnée vecteur, il faut comprendre cette notion comme un schéma de base de données PostgreSQL.
 
-En conséquence si vous disposez d'un lot de données, multi-tables qui a un bénéfice à être traité, mis en forme et diffusé comme un tout, il est recommandé de l'importer sur la Géoplateforme comme une seule livraison.
-
-- Soit au moyen d'un format de fichier gérant le multi-tables (comme le Geopackage)
-- Soit en répétant la requête de remplissage de la livraison autant de fois qu'il ya de fichiers tables unitaires composant votre lot de données.
+En conséquence si vous disposez d’un lot de données, multi-tables qui a un bénéfice à être traité, mis en forme et diffusé comme un tout, il est recommandé de l’importer sur la Géoplateforme comme une seule livraison.
+- Soit au moyen d’un format de fichier gérant le multi-tables (comme le GeoPackage)
+- Soit en répétant la requête de remplissage de la livraison autant de fois qu’il y a de fichiers tables unitaires composant votre lot de données.
 :::
-
 ???
 ????
 <br>
@@ -266,7 +255,7 @@ Lorsque toutes les vérifications seront passées, la livraison passera en statu
 ????
 <br>
 
-En cas d'échec d'une des vérifications, vous disposez d'une route de log pour investiguer sur les raisons de cet échec :
+En cas d’échec d’une des vérifications, vous disposez d’une route de log pour investiguer sur les raisons de cet échec :
 
 ???? GET "{{ urls.api_entrepot }}/datastores/{datastore}/checks/executions/{execution}/logs"
 ```plain
@@ -275,26 +264,25 @@ En cas d'échec d'une des vérifications, vous disposez d'une route de log pour 
 ??? Corps de réponse JSON
 ```json
 [
-  "2026-07-24 00:12:00,863INFO||gpf-vector-checker||7||Récupération des fichiers de la livraison",
-  "2026-07-24 00:12:00,865INFO||cli||255||Vérification VectorChecker (2.14.0) pour la livraison 7b2498a8-5f6c-4169-9ffa-a5bb0ec3ac97",
-  "2026-07-24 00:12:00,876INFO||core||134||1 fichiers à analyser dans la livraison",
-  "2026-07-24 00:12:00,876INFO||cli||255||Multithreading désactivé (exécution dans le thread principal).",
-  "2026-07-24 00:12:00,876INFO||core||179||Analyse du fichier : ma_data.gpkg",
-  "2026-07-24 00:12:00,876INFO||checks_ogr||342||Ouverture du fichier ma_data.gpkg",
-  "2026-07-24 00:12:00,950INFO||checks_ogr||342||Nombre de layers : 1",
-  "2026-07-24 00:12:00,950INFO||checks_ogr||342||----------------------------------------",
-  "2026-07-24 00:12:00,951INFO||checks_ogr||342||Nom du layer : luminaire",
-  "2026-07-24 00:12:00,951INFO||checks_ogr||342||Analyse du SRS",
-  "2026-07-24 00:12:00,981ERROR||checks_ogr||342||Le SRS du layer luminaire est différent de celui déclaré",
-  "2026-07-24 00:12:00,981ERROR||checks_ogr||342||SRS de luminaire : EPSG:4326",
-  "2026-07-24 00:12:00,981ERROR||checks_ogr||342||SRS déclaré : EPSG:2154",
-  "2026-07-24 00:12:00,990WARNING||core||179||Fichier vecteur invalide. Les noms de tables et de colonnes n'ont pas pu être vérifiés.",
-  "2026-07-24 00:12:00,990INFO||cli||255||Résultat de la vérification du fichier : ma_data.gpkg : FAILURE"
+    "2026-07-24 00:12:00,863INFO||gpf-vector-checker||7||Récupération des fichiers de la livraison",
+    "2026-07-24 00:12:00,865INFO||cli||255||Vérification VectorChecker (2.14.0) pour la livraison     7b2498a8-5f6c-4169-9ffa-a5bb0ec3ac97",
+    "2026-07-24 00:12:00,876INFO||core||134||1 fichiers à analyser dans la livraison",
+    "2026-07-24 00:12:00,876INFO||cli||255||Multithreading désactivé (exécution dans le thread principal).",
+    "2026-07-24 00:12:00,876INFO||core||179||Analyse du fichier : ma_data.gpkg",
+    "2026-07-24 00:12:00,876INFO||checks_ogr||342||Ouverture du fichier ma_data.gpkg",
+    "2026-07-24 00:12:00,950INFO||checks_ogr||342||Nombre de layers : 1",
+    "2026-07-24 00:12:00,950INFO||checks_ogr||342||----------------------------------------",
+    "2026-07-24 00:12:00,951INFO||checks_ogr||342||Nom du layer : luminaire",
+    "2026-07-24 00:12:00,951INFO||checks_ogr||342||Analyse du SRS",
+    "2026-07-24 00:12:00,981ERROR||checks_ogr||342||Le SRS du layer luminaire est différent de celui déclaré",
+    "2026-07-24 00:12:00,981ERROR||checks_ogr||342||SRS de luminaire : EPSG:4326",
+    "2026-07-24 00:12:00,981ERROR||checks_ogr||342||SRS déclaré : EPSG:2154",
+    "2026-07-24 00:12:00,990WARNING||core||179||Fichier vecteur invalide. Les noms de tables et de colonnes n'ont pas pu être vérifiés.",
+    "2026-07-24 00:12:00,990INFO||cli||255||Résultat de la vérification du fichier : ma_data.gpkg : FAILURE"
 ]
 ```
-Ici par exemple, l'erreur vient du fait que le fichier livré a été lu comme étant en projection EPSG:4326 tandis que la requête de déclaration de livraison indiquait un fichier en EPSG:2154. Il convient donc :
+Ici par exemple, l’erreur vient du fait que le fichier livré a été lu comme étant en projection EPSG:4326 tandis que la requête de déclaration de livraison indiquait un fichier en EPSG:2154. Il convient donc :
 - soit de re-livrer le fichier en EPSG:2154
 - soit de re-créer une livraison dont la projection attendue sera EPSG:4326
-
 ???
 ????

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/livraison.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/livraison.md
@@ -56,6 +56,41 @@ La livraison n’a qu’un rôle temporaire, le temps que les données soient tr
 }
 ```
 ???
+??? Plus d'aide sur la déclaration de la livraison
+- La livraison est une entité qui permet de déposer un ensemble de fichiers de données au sein de l'entrepôt. Une livraison et son contenu seront toujours utilisés comme un tout.
+
+:::warning
+La livraison n'a qu'un rôle temporaire, le temps que les données soient transformées et stockées dans leur format pérenne sur la plateforme. Les fichiers déposés ne sont pas ceux utilisés par les services de diffusion.
+
+La livraison doit impérativement être supprimée après la réalisation des étapes "traitement".
+:::
+
+- Dans la requête ci-dessus, {datastore} doit être remplacé par l'identifiant de votre datastore de travail.
+
+- Description des paramètres en entrée :
+    - **_description_** : Permet de décrire le contenu de la livraison en quelques mots. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous (producteur de donnée).** Cette information est modifiable après coup.
+
+    - **_name_** : Permet de nommer cette livraison. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** Cette information est modifiable après coup.
+
+    - **_type_** : Définit le type de la donnée qui va être livrée. Pour ce tutoriel la valuer sera exclusivement **VECTOR**. Cette information n'est pas modifiable après coup. En cas d'erreur vous devrez créer une nouvelle livraison.
+
+    - **_srs_** : Définit la projection des données **en entrée**. Cette projection ne préjuge pas de la projection de diffusion des données. Cette information n'est pas modifiable après coup. En cas d'erreur vous devrez créer une nouvelle livraison.
+
+- On retrouve en sortie, les paramètres et leur valeurs saisis en entrée ainsi que quelques informations supplémentaires :
+    - **_status_** : Le statut de la livraison au sein de l'entrepôt. elle est OPEN (ouverte) après création, ce qui correspond à un état compatible avec l'alimentation à venir de cette livraison.
+
+    - **_contact_** : L'email de contact qui correspond à l'email de contact associé à la communauté qui porte cette livraison.
+
+    - **_size_** : La taille **en octet** de cette livraison (pour le moment à 0 puisque la livraison n'a pas été alimentée). 
+
+    - **_last_event_** : Mentionne la dernière action effectuée sur cette livraison et **le compte utilisateur ayant mené cette action**.
+
+:::warning
+**La seule information réellement essentielle** pour poursuivre l'action de livraison est reprise en fin de réponse : 
+        - **_id** : C'est l'identifiant attribué par l'entrepôt Géoplateforme à la livraison. Cet identifiant doit être **obligatoirement récupéré en sortie de la création de la livraison pour être utilisé dans les prochains appels.**
+:::
+ 
+???
 ????
 <br>
 
@@ -77,14 +112,14 @@ Les formats de fichier vecteur gérés sont :
     - CREATE SEQUENCE
     - ALTER TABLE
     - ALTER SEQUENCE
-- FlatGeoBuf
-- Géoparquet (accepté dans la vérification et prochainement dans l'intégration vecteur)
+- FlatGeoBuf (à venir)
+- Géoparquet (à venir)
 
 <br>
 
 📄 `<monde.gpkg>`
 
-??? POST "{{ urls.api_entrepot }}/datastores/{datastore}/uploads/{upload}/data?path=data/monde.gpkg"
+???? POST "{{ urls.api_entrepot }}/datastores/{datastore}/uploads/{upload}/data?path=data/monde.gpkg"
 ```plain
 {{ urls.api_entrepot }}/datastores/{datastore}/uploads/{upload}/data?path=data/monde.gpkg
 ```
@@ -94,7 +129,29 @@ Les formats de fichier vecteur gérés sont :
         ["file = &lt;monde.gpkg&gt;"]
     ]
 }) }}
+??? Plus d'aide sur le remplissage d'une livraison
+
+:::warning
+Dans le paramètre de requête "path" de la requête de remplissage, la valeur à indiquer correspond à l'arborescence de stockage **sur la Géoplateforme**, elle **ne correspond pas** à l'arborescence de stockage du fichier sur votre environnement.
+
+Le paramètre file est lui réservé à pointer vers le fichier là où il se trouve **sur votre environnement**.
+:::
+
+:::info
+Une requête de livraison ne prend qu'un seul fichier en entrée par requête. Si vous livrez un fichier SHP, vous devrez donc répéter la requête de livraison en adaptant la valeur de "path" et de "file" **pour chaque fichier composant le SHP**. Donc a minima un appel pour le .shp, un second pour le .shx et un troisième pour le .prj
+:::
+
+:::info
+Une livraison est traitée comme un tout. Cela signifie qu'une livraison débouche sur la création d'une donnée stockée pérenne sur votre entrepôt. dans le cas d'une donnée vecteur, il faut comprendre cette notion comme un schéma de base de données PostgreSQL.
+
+En conséquence si vous disposez d'un lot de données, multi-tables qui a un bénéfice à être traité, mis en forme et diffusé comme un tout, il est recommandé de l'importer sur la Géoplateforme comme une seule livraison.
+
+- Soit au moyen d'un format de fichier gérant le multi-tables (comme le Geopackage)
+- Soit en répétant la requête de remplissage de la livraison autant de fois qu'il ya de fichiers tables unitaires composant votre lot de données.
+:::
+
 ???
+????
 <br>
 
 #### Contrôler le contenu
@@ -205,5 +262,39 @@ Lorsque toutes les vérifications seront passées, la livraison passera en statu
     "failed": []
 }
 ```
+???
+????
+<br>
+
+En cas d'échec d'une des vérifications, vous disposez d'une route de log pour investiguer sur les raisons de cet échec :
+
+???? GET "{{ urls.api_entrepot }}/datastores/{datastore}/checks/executions/{execution}/logs"
+```plain
+{{ urls.api_entrepot }}/datastores/{datastore}/checks/executions/{execution}/logs
+```
+??? Corps de réponse JSON
+```json
+[
+  "2026-07-24 00:12:00,863INFO||gpf-vector-checker||7||Récupération des fichiers de la livraison",
+  "2026-07-24 00:12:00,865INFO||cli||255||Vérification VectorChecker (2.14.0) pour la livraison 7b2498a8-5f6c-4169-9ffa-a5bb0ec3ac97",
+  "2026-07-24 00:12:00,876INFO||core||134||1 fichiers à analyser dans la livraison",
+  "2026-07-24 00:12:00,876INFO||cli||255||Multithreading désactivé (exécution dans le thread principal).",
+  "2026-07-24 00:12:00,876INFO||core||179||Analyse du fichier : ma_data.gpkg",
+  "2026-07-24 00:12:00,876INFO||checks_ogr||342||Ouverture du fichier ma_data.gpkg",
+  "2026-07-24 00:12:00,950INFO||checks_ogr||342||Nombre de layers : 1",
+  "2026-07-24 00:12:00,950INFO||checks_ogr||342||----------------------------------------",
+  "2026-07-24 00:12:00,951INFO||checks_ogr||342||Nom du layer : luminaire",
+  "2026-07-24 00:12:00,951INFO||checks_ogr||342||Analyse du SRS",
+  "2026-07-24 00:12:00,981ERROR||checks_ogr||342||Le SRS du layer luminaire est différent de celui déclaré",
+  "2026-07-24 00:12:00,981ERROR||checks_ogr||342||SRS de luminaire : EPSG:4326",
+  "2026-07-24 00:12:00,981ERROR||checks_ogr||342||SRS déclaré : EPSG:2154",
+  "2026-07-24 00:12:00,990WARNING||core||179||Fichier vecteur invalide. Les noms de tables et de colonnes n'ont pas pu être vérifiés.",
+  "2026-07-24 00:12:00,990INFO||cli||255||Résultat de la vérification du fichier : ma_data.gpkg : FAILURE"
+]
+```
+Ici par exemple, l'erreur vient du fait que le fichier livré a été lu comme étant en projection EPSG:4326 tandis que la requête de déclaration de livraison indiquait un fichier en EPSG:2154. Il convient donc :
+- soit de re-livrer le fichier en EPSG:2154
+- soit de re-créer une livraison dont la projection attendue sera EPSG:4326
+
 ???
 ????

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-tmsv.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-tmsv.md
@@ -54,39 +54,23 @@ Dans le cas du TMS Vecteur, une configuration va donner plusieurs couches finale
 }
 ```
 ???
-??? Plus d'aide sur la configuration VECTOR-TMS
-- Description des paramètres en entrée :
-    - **_type_** : La valeur est contrainte par une liste de valeur définie à tout moment dans le swagger. "VECTOR-TMS" pour une publication en tuiles vectorielles calculées à la volée. La définition de cette valeur est sensible à la casse.
-
-    - **_name_** : Permet de nommer cette configuration. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** Cette information est modifiable après coup.
-
-    - **_layer_name**_ : Définit le nom technique par lequel le flux sera rendu disponible au sein du webservice. **Cette information est visible de l'utilisateur final**
-
-    - **_type_infos_** : L'essentiel des spécificités de la configuration liées à vos données est à retrouver ici : 
-
-        
-
-        
-
-        - **_keywords_** : Il s'agit d'une liste de mots clés, chaque mot ou expression clé étant placée entre doubles quotes, pour permettre à un utilisateur de retrouver plus facilement une donnée. **Cette information est visible de l'utilisateur final**
-
-        - **_bbox_** : Permet de forcer une bbox lors de la publication. Les valeurs de coordonnées sont systématiquement à renseigner en EPSG:4326. 
+??? Plus d’aide sur la configuration VECTOR-TMS
+Description des paramètres en entrée :
+- `type` : La valeur est contrainte par une liste de valeurs définies à tout moment dans le swagger. `VECTOR-TMS` pour une publication en tuiles vectorielles calculées à la volée. La définition de cette valeur est sensible à la casse.
+- `name` : Permet de nommer cette configuration. **Cette information n’est lisible que par un autre utilisateur membre de cet entrepôt, pas par l’utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour vous - producteur de donnée.** Cette information est modifiable après coup.
+- `layer_name` : Définit le nom technique par lequel le flux sera rendu disponible au sein du webservice. **Cette information est visible de l’utilisateur final.**
+- `type_infos` : L’essentiel des spécificités de la configuration liées à vos données est à retrouver ici :
+    - `keywords` : Il s’agit d’une liste de mots clés, chaque mot ou expression clé étant placée entre doubles quotes, pour permettre à un utilisateur de retrouver plus facilement une donnée. **Cette information est visible de l’utilisateur final**
+    - `bbox` : Permet de forcer une `bbox` lors de la publication. Les valeurs de coordonnées sont systématiquement à renseigner en EPSG:4326.
         :::info
-        L'élément "bbox" est optionnel, s'il n'est pas mentionné dans la configuration, le système calcule automatiquement l'emprise du service publié à partir de l'emprise de la stored_data renseignée plus bas.
+        L’élément `bbox` est optionnel, s’il n’est pas mentionné dans la configuration, le système calcule automatiquement l’emprise du service publié à partir de l’emprise de la `stored_data` renseignée plus bas.
         :::
-
-        - **_used_data_** : Permet de définir, au sein d'une stored_data placée comme dernier paramètre de l'élément, les couches de données qui seront publiées. ainsi une offre WFS peut permettre de publier plusieurs couches de données unitaires :
-
-            - **_relations_** : Il s'agit de la liste des couches à publier. Pour chacune on retrouve la possibilité de définir 4 éléments :
-
-                - **_native_name_** :  C'est le nom technique de la couche tel qu'il est défini dans la stored_data.
-
-                - **_public_name_** : C'est le nom technique (donc sans espace, accent ou autre caractère spécial) sous lequel vous voulez publier la couche.  **Cette information est visible de l'utilisateur final**
-
-                - **_abstract_** : Présente une courte description informative en toutes lettre de la couche publiée (ou du lot de couche publié). **Cette information est visible de l'utilisateur final**
-
- 
-            - **_stored_data_** : Il s'agit ici de l'identifiant entrepôt de la stored_data qui va être publiée
+    - `used_data` : Permet de définir, au sein d’une `stored_data` placée comme dernier paramètre de l’élément, les couches de données qui seront publiées. Ainsi une offre TMS Vecteur peut permettre de publier plusieurs couches de données unitaires :
+        - `relations` : Il s’agit de la liste des couches à publier. Pour chacune on retrouve la possibilité de définir 4 éléments :
+            - `native_name` :  C’est le nom technique de la couche tel qu’il est défini dans la `stored_data`.
+            - `public_name` : C’est le nom technique (donc sans espace, accent ou autre caractère spécial) sous lequel vous voulez publier la couche. **Cette information est visible de l’utilisateur final.**
+            - `abstract` : Présente une courte description informative en toutes lettres de la couche publiée (ou du lot de couches publié). **Cette information est visible de l’utilisateur final.**
+        - `stored_data` : Il s’agit ici de l’identifiant entrepôt de la `stored_data` qui va être publiée.
 ???
 ????
 <br>
@@ -108,17 +92,15 @@ Si on ne précise pas de `public_name`, c’est le nom natif de stockage qui est
 {{ "public/data/tutoriels/alimentation-diffusion-simple/globales/production/endpoints.json" | readFILE | safe }}
 ```
 ???
-
 :::info
-Pour la publication de tuiles vectorielles calculées à la volée, seul le mode opendata est proposé par la Géoplateforme.
+Pour la publication de tuiles vectorielles calculées à la volée, seul le mode <span lang="en">_open data_</span> est proposé par la Géoplateforme.
 :::
-
 ????
 <br>
 
 #### Publication
 
-??? POST "{{ urls.api_entrepot }}/datastores/{datastore}/configurations/{configuration tms vecteur}/offerings"
+???? POST "{{ urls.api_entrepot }}/datastores/{datastore}/configurations/{configuration tms vecteur}/offerings"
 ```plain
 {{ urls.api_entrepot }}/datastores/{datastore}/configurations/{configuration tms vecteur}/offerings
 ```
@@ -130,11 +112,9 @@ Pour la publication de tuiles vectorielles calculées à la volée, seul le mode
 }
 ```
 ???
-
 :::info
-Pour la publication de tuiles vectorielles calculées à la volée, seul le mode opendata est proposé par la Géoplateforme.
+Pour la publication de tuiles vectorielles calculées à la volée, seul le mode <span lang="en">_open data_</span> est proposé par la Géoplateforme.
 :::
-
 ????
 <br>
 

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-tmsv.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-tmsv.md
@@ -54,6 +54,40 @@ Dans le cas du TMS Vecteur, une configuration va donner plusieurs couches finale
 }
 ```
 ???
+??? Plus d'aide sur la configuration VECTOR-TMS
+- Description des paramètres en entrée :
+    - **_type_** : La valeur est contrainte par une liste de valeur définie à tout moment dans le swagger. "VECTOR-TMS" pour une publication en tuiles vectorielles calculées à la volée. La définition de cette valeur est sensible à la casse.
+
+    - **_name_** : Permet de nommer cette configuration. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** Cette information est modifiable après coup.
+
+    - **_layer_name**_ : Définit le nom technique par lequel le flux sera rendu disponible au sein du webservice. **Cette information est visible de l'utilisateur final**
+
+    - **_type_infos_** : L'essentiel des spécificités de la configuration liées à vos données est à retrouver ici : 
+
+        
+
+        
+
+        - **_keywords_** : Il s'agit d'une liste de mots clés, chaque mot ou expression clé étant placée entre doubles quotes, pour permettre à un utilisateur de retrouver plus facilement une donnée. **Cette information est visible de l'utilisateur final**
+
+        - **_bbox_** : Permet de forcer une bbox lors de la publication. Les valeurs de coordonnées sont systématiquement à renseigner en EPSG:4326. 
+        :::info
+        L'élément "bbox" est optionnel, s'il n'est pas mentionné dans la configuration, le système calcule automatiquement l'emprise du service publié à partir de l'emprise de la stored_data renseignée plus bas.
+        :::
+
+        - **_used_data_** : Permet de définir, au sein d'une stored_data placée comme dernier paramètre de l'élément, les couches de données qui seront publiées. ainsi une offre WFS peut permettre de publier plusieurs couches de données unitaires :
+
+            - **_relations_** : Il s'agit de la liste des couches à publier. Pour chacune on retrouve la possibilité de définir 4 éléments :
+
+                - **_native_name_** :  C'est le nom technique de la couche tel qu'il est défini dans la stored_data.
+
+                - **_public_name_** : C'est le nom technique (donc sans espace, accent ou autre caractère spécial) sous lequel vous voulez publier la couche.  **Cette information est visible de l'utilisateur final**
+
+                - **_abstract_** : Présente une courte description informative en toutes lettre de la couche publiée (ou du lot de couche publié). **Cette information est visible de l'utilisateur final**
+
+ 
+            - **_stored_data_** : Il s'agit ici de l'identifiant entrepôt de la stored_data qui va être publiée
+???
 ????
 <br>
 
@@ -74,6 +108,11 @@ Si on ne précise pas de `public_name`, c’est le nom natif de stockage qui est
 {{ "public/data/tutoriels/alimentation-diffusion-simple/globales/production/endpoints.json" | readFILE | safe }}
 ```
 ???
+
+:::info
+Pour la publication de tuiles vectorielles calculées à la volée, seul le mode opendata est proposé par la Géoplateforme.
+:::
+
 ????
 <br>
 
@@ -91,6 +130,11 @@ Si on ne précise pas de `public_name`, c’est le nom natif de stockage qui est
 }
 ```
 ???
+
+:::info
+Pour la publication de tuiles vectorielles calculées à la volée, seul le mode opendata est proposé par la Géoplateforme.
+:::
+
 ????
 <br>
 

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-wfs.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-wfs.md
@@ -64,6 +64,35 @@ Dans le cas du WFS, une configuration va donner plusieurs couches finales, le `l
 }
 ```
 ???
+??? Pour plus d'aide sur la création d'une configuration WFS
+- Description des paramètres en entrée :
+    - **_type_** : La valeur est contrainte par une liste de valeur définie à tout moment dans le swagger. "WFS" pour une publication WFS. La définition de cette valeur est sensible à la casse.
+
+    - **_name_** : Permet de nommer cette configuration. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** Cette information est modifiable après coup.
+
+    - **_layer_name**_ : Définit le nom technique par lequel le flux sera rendu disponible au sein du webservice. **Cette information est visible de l'utilisateur final**
+
+    - **_type_infos_** : L'essentiel des spécificités de la configuration liées à vos données est à retrouver ici : 
+
+        - **_bbox_** : Permet de forcer une bbox lors de la publication. Les valeurs de coordonnées sont systématiquement à renseigner en EPSG:4326. 
+        :::info
+        L'élément "bbox" est optionnel, s'il n'est pas mentionné dans la configuration, le système calcule automatiquement l'emprise du service publié à partir de l'emprise de la stored_data renseignée plus bas.
+        :::
+
+        - **_used_data_** : Permet de définir, au sein d'une stored_data placée comme dernier paramètre de l'élément, les couches de données qui seront publiées. ainsi une offre WFS peut permettre de publier plusieurs couches de données unitaires :
+
+            - **_relations_** : Il s'agit de la liste des couches à publier. Pour chacune on retrouve la possibilité de définir 4 éléments :
+
+                - **_native_name_** :  C'est le nom technique de la couche tel qu'il est défini dans la stored_data. **Si le public name n'est pas défini, cette information est visible de l'utilisateur final**
+
+                - **_public_name_** : C'est le nom technique (donc sans espace, accent ou autre caractère spécial) sous lequel vous voulez publier la couche.  **Cette information est visible de l'utilisateur final**
+
+                - **_keywords_** : Il s'agit d'une liste de mots clés, chaque mot ou expression clé étant placée entre doubles quotes, pour permettre à un utilisateur de retrouver plus facilement une donnée. **Cette information est visible de l'utilisateur final**
+
+                - **_abstract_** : Présente une courte description informative en toutes lettre de la couche publiée. **Cette information est visible de l'utilisateur final**
+            
+            - **_stored_data_** : Il s'agit ici de l'identifiant entrepôt de la stored_data qui va être publiée
+???
 ????
 <br>
 
@@ -84,6 +113,18 @@ Si on ne précise pas de `public_name`, c’est le nom natif de stockage qui est
 {{ "public/data/tutoriels/alimentation-diffusion-simple/globales/production/endpoints.json" | readFILE | safe }}
 ```
 ???
+??? Plus d'aide sur le choix de son point de diffusion
+
+Cette étape est l'étape clé pour décider si le flux que vous vous apprêtez à publier va être publié en opendata ou au contraire seulement aux utilisateurs accrédités. Dans l'écosystème Géoplateforme on appelle ce dernier mode, le mode privé.
+
+Si vous souhaitez publier en opendata, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à true**.
+
+Si vous souhaitez publier en mode **privé**, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à false**.
+
+Le tutoriel est déroulé en mode opendata. Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
+
+
+???
 ????
 <br>
 
@@ -100,6 +141,21 @@ Si on ne précise pas de `public_name`, c’est le nom natif de stockage qui est
     "open": true
 }
 ```
+???
+??? Plus d'aide sur la configuration de la publication
+
+L'exemple ci-dessus présente une publication en mode opendata.
+
+Si vous choisissez de publier en mode privé, le corps de requête sera : 
+
+```json
+{
+    "endpoint": "{{ ids.endpoints.private.wfs }}",
+    "open": false
+}
+```
+Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
+
 ???
 ????
 <br>

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-wfs.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-wfs.md
@@ -64,34 +64,23 @@ Dans le cas du WFS, une configuration va donner plusieurs couches finales, le `l
 }
 ```
 ???
-??? Pour plus d'aide sur la création d'une configuration WFS
-- Description des paramètres en entrée :
-    - **_type_** : La valeur est contrainte par une liste de valeur définie à tout moment dans le swagger. "WFS" pour une publication WFS. La définition de cette valeur est sensible à la casse.
-
-    - **_name_** : Permet de nommer cette configuration. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** Cette information est modifiable après coup.
-
-    - **_layer_name**_ : Définit le nom technique par lequel le flux sera rendu disponible au sein du webservice. **Cette information est visible de l'utilisateur final**
-
-    - **_type_infos_** : L'essentiel des spécificités de la configuration liées à vos données est à retrouver ici : 
-
-        - **_bbox_** : Permet de forcer une bbox lors de la publication. Les valeurs de coordonnées sont systématiquement à renseigner en EPSG:4326. 
+??? Pour plus d’aide sur la création d’une configuration WFS
+Description des paramètres en entrée :
+- `type` : La valeur est contrainte par une liste de valeurs définies à tout moment dans le swagger. `WFS` pour une publication WFS. La définition de cette valeur est sensible à la casse.
+- `name` : Permet de nommer cette configuration. **Cette information n’est lisible que par un autre utilisateur membre de cet entrepôt, pas par l’utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour vous - producteur de donnée.** Cette information est modifiable après coup.
+- `layer_name` : Définit le nom technique par lequel le flux sera rendu disponible au sein du webservice. **Cette information est visible de l’utilisateur final.**
+- `type_infos` : L’essentiel des spécificités de la configuration liées à vos données est à retrouver ici :
+    - `bbox` : Permet de forcer une `bbox` lors de la publication. Les valeurs de coordonnées sont systématiquement à renseigner en EPSG:4326.
         :::info
-        L'élément "bbox" est optionnel, s'il n'est pas mentionné dans la configuration, le système calcule automatiquement l'emprise du service publié à partir de l'emprise de la stored_data renseignée plus bas.
+        L’élément `bbox` est optionnel, s’il n’est pas mentionné dans la configuration, le système calcule automatiquement l’emprise du service publié à partir de l’emprise de la `stored_data` renseignée plus bas.
         :::
-
-        - **_used_data_** : Permet de définir, au sein d'une stored_data placée comme dernier paramètre de l'élément, les couches de données qui seront publiées. ainsi une offre WFS peut permettre de publier plusieurs couches de données unitaires :
-
-            - **_relations_** : Il s'agit de la liste des couches à publier. Pour chacune on retrouve la possibilité de définir 4 éléments :
-
-                - **_native_name_** :  C'est le nom technique de la couche tel qu'il est défini dans la stored_data. **Si le public name n'est pas défini, cette information est visible de l'utilisateur final**
-
-                - **_public_name_** : C'est le nom technique (donc sans espace, accent ou autre caractère spécial) sous lequel vous voulez publier la couche.  **Cette information est visible de l'utilisateur final**
-
-                - **_keywords_** : Il s'agit d'une liste de mots clés, chaque mot ou expression clé étant placée entre doubles quotes, pour permettre à un utilisateur de retrouver plus facilement une donnée. **Cette information est visible de l'utilisateur final**
-
-                - **_abstract_** : Présente une courte description informative en toutes lettre de la couche publiée. **Cette information est visible de l'utilisateur final**
-            
-            - **_stored_data_** : Il s'agit ici de l'identifiant entrepôt de la stored_data qui va être publiée
+    - `used_data` : Permet de définir, au sein d’une `stored_data` placée comme dernier paramètre de l’élément, les couches de données qui seront publiées. Ainsi une offre WFS peut permettre de publier plusieurs couches de données unitaires :
+        - `relations` : Il s’agit de la liste des couches à publier. Pour chacune on retrouve la possibilité de définir 4 éléments :
+            - `native_name` :  C’est le nom technique de la couche tel qu’il est défini dans la `stored_data`. **Si le public name n’est pas défini, cette information est visible de l’utilisateur final.**
+            - `public_name` : C’est le nom technique (donc sans espace, accent ou autre caractère spécial) sous lequel vous voulez publier la couche. **Cette information est visible de l’utilisateur final.**
+            - `keywords` : Il s’agit d’une liste de mots clés, chaque mot ou expression clé étant placée entre doubles quotes, pour permettre à un utilisateur de retrouver plus facilement une donnée. **Cette information est visible de l’utilisateur final.**
+            - `abstract` : Présente une courte description informative en toutes lettre de la couche publiée. **Cette information est visible de l’utilisateur final.**
+        - `stored_data` : Il s’agit ici de l’identifiant entrepôt de la `stored_data` qui va être publiée.
 ???
 ????
 <br>
@@ -113,17 +102,14 @@ Si on ne précise pas de `public_name`, c’est le nom natif de stockage qui est
 {{ "public/data/tutoriels/alimentation-diffusion-simple/globales/production/endpoints.json" | readFILE | safe }}
 ```
 ???
-??? Plus d'aide sur le choix de son point de diffusion
+??? Plus d’aide sur le choix de son point de diffusion
+Cette étape est l’étape clé pour décider si le flux que vous vous apprêtez à publier va être publié en <span lang="en">_open data_</span> ou au contraire seulement aux utilisateurs accrédités. Dans l’écosystème Géoplateforme on appelle ce dernier mode, le mode privé.
 
-Cette étape est l'étape clé pour décider si le flux que vous vous apprêtez à publier va être publié en opendata ou au contraire seulement aux utilisateurs accrédités. Dans l'écosystème Géoplateforme on appelle ce dernier mode, le mode privé.
+Si vous souhaitez publier en <span lang="en">_open data_</span>, vous allez chercher, dans la réponse ci-dessus, un <span lang="en">_endpoint_</span> du type de la configuration créée (pour le tutoriel, `WFS`) dont **l’élément `open` est à `true`**.
 
-Si vous souhaitez publier en opendata, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à true**.
+Si vous souhaitez publier en mode **privé**, vous allez chercher, dans la réponse ci-dessus, un <span lang="en">_endpoint_</span> du type de la configuration créée (pour le tutoriel, `WFS`) dont **l’élément `open` est à `false`**.
 
-Si vous souhaitez publier en mode **privé**, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à false**.
-
-Le tutoriel est déroulé en mode opendata. Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
-
-
+Le tutoriel est déroulé en mode <span lang="en">_open data_</span>. Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](../../../controle-des-acces/service-de-diffusion/).
 ???
 ????
 <br>
@@ -142,20 +128,17 @@ Le tutoriel est déroulé en mode opendata. Pour accéder à une donnée publié
 }
 ```
 ???
-??? Plus d'aide sur la configuration de la publication
+??? Plus d’aide sur la configuration de la publication
+L’exemple ci-dessus présente une publication en mode <span lang="en">_open data_</span>.
 
-L'exemple ci-dessus présente une publication en mode opendata.
-
-Si vous choisissez de publier en mode privé, le corps de requête sera : 
-
+Si vous choisissez de publier en mode privé, le corps de requête sera :
 ```json
 {
     "endpoint": "{{ ids.endpoints.private.wfs }}",
     "open": false
 }
 ```
-Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
-
+Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](../../../controle-des-acces/service-de-diffusion/)
 ???
 ????
 <br>

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-wms.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-wms.md
@@ -61,38 +61,25 @@ La création de la configuration WMS va permettre de vérifier de nombreuses inf
 }
 ```
 ???
-??? Plus d'aide sur la configuration WMS-V
-- Description des paramètres en entrée :
-    - **_type_** : La valeur est contrainte par une liste de valeur définie à tout moment dans le swagger. "WMS-V" pour une publication WMS à partir de données vecteur. La définition de cette valeur est sensible à la casse.
-
-    - **_name_** : Permet de nommer cette configuration. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** Cette information est modifiable après coup.
-
-    - **_layer_name_** : Définit le nom technique par lequel le flux sera rendu disponible au sein du webservice. **Cette information est visible de l'utilisateur final**
-
-    - **_type_infos_** : L'essentiel des spécificités de la configuration liées à vos données est à retrouver ici : 
-
-        - **_title_** : C'est le titre en texte libre (accents, espaces, minuscules et majuscules autorisés) de votre service web. **Cette information est visible de l'utilisateur final**
-
-        - **_abstract_** : Présente une courte description informative en toutes lettre de la couche publiée (ou du lot de couche publié). **Cette information est visible de l'utilisateur final**
-
-        - **_keywords_** : Il s'agit d'une liste de mots clés, chaque mot ou expression clé étant placée entre doubles quotes, pour permettre à un utilisateur de retrouver plus facilement une donnée. **Cette information est visible de l'utilisateur final**
-
-        - **_bbox_** : Permet de forcer une bbox lors de la publication. Les valeurs de coordonnées sont systématiquement à renseigner en EPSG:4326. 
+??? Plus d’aide sur la configuration WMS-V
+Description des paramètres en entrée :
+- `type` : La valeur est contrainte par une liste de valeurs définies à tout moment dans le swagger. `WMS-V` pour une publication WMS à partir de données vecteur. La définition de cette valeur est sensible à la casse.
+- `name` : Permet de nommer cette configuration. **Cette information n’est lisible que par un autre utilisateur membre de cet entrepôt, pas par l’utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour vous - producteur de donnée.** Cette information est modifiable après coup.
+- `layer_name` : Définit le nom technique par lequel le flux sera rendu disponible au sein du webservice. **Cette information est visible de l’utilisateur final.**
+- `type_infos` : L’essentiel des spécificités de la configuration liées à vos données est à retrouver ici :
+    - `title` : C’est le titre en texte libre (accents, espaces, minuscules et majuscules autorisés) de votre service web. **Cette information est visible de l’utilisateur final.**
+    - `abstract` : Présente une courte description informative en toutes lettres de la couche publiée (ou du lot de couche publié). **Cette information est visible de l’utilisateur final.**
+    - `keywords` : Il s’agit d’une liste de mots clés, chaque mot ou expression clé étant placée entre doubles quotes, pour permettre à un utilisateur de retrouver plus facilement une donnée. **Cette information est visible de l’utilisateur final.**
+    - `bbox` : Permet de forcer une `bbox` lors de la publication. Les valeurs de coordonnées sont systématiquement à renseigner en EPSG:4326.
         :::info
-        L'élément "bbox" est optionnel, s'il n'est pas mentionné dans la configuration, le système calcule automatiquement l'emprise du service publié à partir de l'emprise de la stored_data renseignée plus bas.
+        L’élément `bbox` est optionnel, s’il n’est pas mentionné dans la configuration, le système calcule automatiquement l’emprise du service publié à partir de l’emprise de la `stored_data` renseignée plus bas.
         :::
-
-        - **_used_data_** : Permet de définir, au sein d'une stored_data placée comme dernier paramètre de l'élément, les couches de données qui seront publiées. ainsi une offre WFS peut permettre de publier plusieurs couches de données unitaires :
-
-            - **_relations_** : Il s'agit de la liste des couches à publier. Pour chacune on retrouve la possibilité de définir 4 éléments :
-
-                - **name_** :  C'est le nom technique de la couche tel qu'il est défini dans la stored_data.
-
-                - **_sld_** : C'est l'identifiant entrepôt (_id) du fichier de style sld chargé à l'étape précédente. **Cette information est optionnelle**. Si un tel fichier n'est mentionné, la couche sera rendue en bleu, style par défaut, sans que l'utilisateur final puisse influer sur le rendu.
-
-                - **_ftl_** : C'est l'identifiant entrepôt (_id) du fichier de présentation des attributs ftl chargé à l'étape précédente.**Cette information est optionnelle**. Si un tel fichier n'est mentionné, l'ensemble des attributs est présenté par l'opération getFeatureInfo du WMS.
- 
-            - **_stored_data_** : Il s'agit ici de l'identifiant entrepôt de la stored_data qui va être publiée
+    - `used_data` : Permet de définir, au sein d’une `stored_data` placée comme dernier paramètre de l’élément, les couches de données qui seront publiées. Ainsi une offre WMS peut permettre de publier plusieurs couches de données unitaires :
+        - `relations` : Il s’agit de la liste des couches à publier. Pour chacune on retrouve la possibilité de définir 4 éléments :
+            - `name` :  C’est le nom technique de la couche tel qu’il est défini dans la `stored_data`.
+            - `sld` : C’est l’identifiant entrepôt (`_id`) du fichier de style SLD chargé à l’étape précédente. **Cette information est optionnelle**. Si un tel fichier n’est mentionné, la couche sera rendue en bleu, style par défaut, sans que l’utilisateur final puisse influer sur le rendu.
+            - `ftl` : C’est l’identifiant entrepôt (`_id`) du fichier de présentation des attributs FTL chargé à l’étape précédente. **Cette information est optionnelle**. Si un tel fichier n’est mentionné, l’ensemble des attributs est présenté par l’opération `getFeatureInfo` du WMS.
+        - `stored_data` : Il s’agit ici de l’identifiant entrepôt de la `stored_data` qui va être publiée
 ???
 ????
 <br>
@@ -100,7 +87,7 @@ La création de la configuration WMS va permettre de vérifier de nombreuses inf
 :::warning
 Une configuration WMS-VECTOR donnera une unique couche. Même si elle utilise plusieurs tables, ces dernières ne seront pas consultables individuellement en WMS. Si c’est votre besoin, faites une configuration (et donc une couche) par table.
 
-Dans le cas où vous souhaitez bien déclarer plusieurs table dans votre WMS, pense zà régler correctement l'ordre des couches dans l'élément json "used_data"/"relations" : La première couche lisible sera au dessus, la dernière tou en dessous.
+Dans le cas où vous souhaitez bien déclarer plusieurs tables dans votre WMS, pensez à régler correctement l’ordre des couches dans l’élément JSON `used_data.relations` : la première couche lisible sera au-dessus, la dernière tout en dessous.
 :::
 
 ### Envoi sur les services de diffusion
@@ -118,17 +105,14 @@ Comme pour le WFS, seule la création d’une offre sur un point d’accès (pub
 {{ "public/data/tutoriels/alimentation-diffusion-simple/globales/production/endpoints.json" | readFILE | safe }}
 ```
 ???
-??? Plus d'aide sur le choix de son point de diffusion
+??? Plus d’aide sur le choix de son point de diffusion
+Cette étape est l’étape clé pour décider si le flux que vous vous apprêtez à publier va être publié en <span lang="en">_open data_</span> ou au contraire seulement aux utilisateurs accrédités. Dans l’écosystème Géoplateforme on appelle ce dernier mode, le mode privé.
 
-Cette étape est l'étape clé pour décider si le flux que vous vous apprêtez à publier va être publié en opendata ou au contraire seulement aux utilisateurs accrédités. Dans l'écosystème Géoplateforme on appelle ce dernier mode, le mode privé.
+Si vous souhaitez publier en <span lang="en">_open data_</span>, vous allez chercher, dans la réponse ci-dessus, un <span lang="en">_endpoint_</span> du type de la configuration créée (pour le tutoriel, `WMS`) dont l’**élément `open` est à `true`**.
 
-Si vous souhaitez publier en opendata, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à true**.
+Si vous souhaitez publier en mode **privé**, vous allez chercher, dans la réponse ci-dessus, un <span lang="en">_endpoint_</span> du type de la configuration créée (pour le tutoriel, `WMS`) dont l’**élément `open` est à `false`**.
 
-Si vous souhaitez publier en mode **privé**, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à false**.
-
-Le tutoriel est déroulé en mode opendata. Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
-
-
+Le tutoriel est déroulé en mode <span lang="en">_open data_</span>. Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](../../../controle-des-acces/service-de-diffusion/).
 ???
 ????
 <br>
@@ -147,20 +131,17 @@ Le tutoriel est déroulé en mode opendata. Pour accéder à une donnée publié
 }
 ```
 ???
-??? Plus d'aide sur la configuration de la publication
+??? Plus d’aide sur la configuration de la publication
+L’exemple ci-dessus présente une publication en mode <span lang="en">_open data_</span>.
 
-L'exemple ci-dessus présente une publication en mode opendata.
-
-Si vous choisissez de publier en mode privé, le corps de requête sera : 
-
+Si vous choisissez de publier en mode privé, le corps de requête sera :
 ```json
 {
     "endpoint": "{{ ids.endpoints.private.wmsv }}",
     "open": false
 }
 ```
-Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
-
+Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](../../../controle-des-acces/service-de-diffusion/)
 ???
 ????
 <br>

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-wms.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/publication-wms.md
@@ -61,11 +61,46 @@ La création de la configuration WMS va permettre de vérifier de nombreuses inf
 }
 ```
 ???
+??? Plus d'aide sur la configuration WMS-V
+- Description des paramètres en entrée :
+    - **_type_** : La valeur est contrainte par une liste de valeur définie à tout moment dans le swagger. "WMS-V" pour une publication WMS à partir de données vecteur. La définition de cette valeur est sensible à la casse.
+
+    - **_name_** : Permet de nommer cette configuration. **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** Cette information est modifiable après coup.
+
+    - **_layer_name_** : Définit le nom technique par lequel le flux sera rendu disponible au sein du webservice. **Cette information est visible de l'utilisateur final**
+
+    - **_type_infos_** : L'essentiel des spécificités de la configuration liées à vos données est à retrouver ici : 
+
+        - **_title_** : C'est le titre en texte libre (accents, espaces, minuscules et majuscules autorisés) de votre service web. **Cette information est visible de l'utilisateur final**
+
+        - **_abstract_** : Présente une courte description informative en toutes lettre de la couche publiée (ou du lot de couche publié). **Cette information est visible de l'utilisateur final**
+
+        - **_keywords_** : Il s'agit d'une liste de mots clés, chaque mot ou expression clé étant placée entre doubles quotes, pour permettre à un utilisateur de retrouver plus facilement une donnée. **Cette information est visible de l'utilisateur final**
+
+        - **_bbox_** : Permet de forcer une bbox lors de la publication. Les valeurs de coordonnées sont systématiquement à renseigner en EPSG:4326. 
+        :::info
+        L'élément "bbox" est optionnel, s'il n'est pas mentionné dans la configuration, le système calcule automatiquement l'emprise du service publié à partir de l'emprise de la stored_data renseignée plus bas.
+        :::
+
+        - **_used_data_** : Permet de définir, au sein d'une stored_data placée comme dernier paramètre de l'élément, les couches de données qui seront publiées. ainsi une offre WFS peut permettre de publier plusieurs couches de données unitaires :
+
+            - **_relations_** : Il s'agit de la liste des couches à publier. Pour chacune on retrouve la possibilité de définir 4 éléments :
+
+                - **name_** :  C'est le nom technique de la couche tel qu'il est défini dans la stored_data.
+
+                - **_sld_** : C'est l'identifiant entrepôt (_id) du fichier de style sld chargé à l'étape précédente. **Cette information est optionnelle**. Si un tel fichier n'est mentionné, la couche sera rendue en bleu, style par défaut, sans que l'utilisateur final puisse influer sur le rendu.
+
+                - **_ftl_** : C'est l'identifiant entrepôt (_id) du fichier de présentation des attributs ftl chargé à l'étape précédente.**Cette information est optionnelle**. Si un tel fichier n'est mentionné, l'ensemble des attributs est présenté par l'opération getFeatureInfo du WMS.
+ 
+            - **_stored_data_** : Il s'agit ici de l'identifiant entrepôt de la stored_data qui va être publiée
+???
 ????
 <br>
 
 :::warning
 Une configuration WMS-VECTOR donnera une unique couche. Même si elle utilise plusieurs tables, ces dernières ne seront pas consultables individuellement en WMS. Si c’est votre besoin, faites une configuration (et donc une couche) par table.
+
+Dans le cas où vous souhaitez bien déclarer plusieurs table dans votre WMS, pense zà régler correctement l'ordre des couches dans l'élément json "used_data"/"relations" : La première couche lisible sera au dessus, la dernière tou en dessous.
 :::
 
 ### Envoi sur les services de diffusion
@@ -83,6 +118,18 @@ Comme pour le WFS, seule la création d’une offre sur un point d’accès (pub
 {{ "public/data/tutoriels/alimentation-diffusion-simple/globales/production/endpoints.json" | readFILE | safe }}
 ```
 ???
+??? Plus d'aide sur le choix de son point de diffusion
+
+Cette étape est l'étape clé pour décider si le flux que vous vous apprêtez à publier va être publié en opendata ou au contraire seulement aux utilisateurs accrédités. Dans l'écosystème Géoplateforme on appelle ce dernier mode, le mode privé.
+
+Si vous souhaitez publier en opendata, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à true**.
+
+Si vous souhaitez publier en mode **privé**, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à false**.
+
+Le tutoriel est déroulé en mode opendata. Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
+
+
+???
 ????
 <br>
 
@@ -99,6 +146,21 @@ Comme pour le WFS, seule la création d’une offre sur un point d’accès (pub
     "open": true
 }
 ```
+???
+??? Plus d'aide sur la configuration de la publication
+
+L'exemple ci-dessus présente une publication en mode opendata.
+
+Si vous choisissez de publier en mode privé, le corps de requête sera : 
+
+```json
+{
+    "endpoint": "{{ ids.endpoints.private.wmsv }}",
+    "open": false
+}
+```
+Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
+
 ???
 ????
 <br>

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/tuilage.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/tuilage.md
@@ -1,7 +1,7 @@
 ---
-title: Diffusion en tuiles vectorielles précalculée
+title: Diffusion en tuiles vectorielles précalculées
 eleventyNavigation:
-    key: Diffusion en tuiles vectorielles précalculée
+    key: Diffusion en tuiles vectorielles précalculées
     order: 7
 eleventyComputed:
     markdownTemplateEngine: njk
@@ -15,7 +15,7 @@ tertiaryTitle: Tuilage
 
 Cette étape supplémentaire permet une diffusion à plus grande échelle de données vecteur. Seules les parties nouvelles sont détaillées.
 
-### Calcul de la pyramide de tuiles vectorielle
+### Calcul de la pyramide de tuiles vectorielles
 
 #### Consultation des traitements disponibles
 
@@ -152,7 +152,7 @@ Dans notre exemple ici, on choisit un cas simple : les pays sont présents dans
     "output": {
         "stored_data": {
             "name": "Pays et éco-régions",
-            "storage_tags": ["PYARAMIDE"]
+            "storage_tags": ["PYRAMIDE"]
         }
     },
     "parameters": {
@@ -174,79 +174,62 @@ Dans notre exemple ici, on choisit un cas simple : les pays sont présents dans
 }
 ```
 ???
-??? Plus d'aide sur la configuration d'une exécution de traitement de création d'une pyramide de tuiles vectorielles.
-- Description des paramètres en entrée :
-    - **_inputs/stored_data_** :  Il s'agit ici d'une liste (présence des caractères [ ]) qui prend comme valeur au moins un identifiant entrepôt de **stored_data** de type VECTOR-DB (voir étape précédente)
-    - **_output/stored_data/name_** : Le nom définit ici est un nommage libre.
+??? Plus d’aide sur la configuration d’une exécution de traitement de création d’une pyramide de tuiles vectorielles
+Description des paramètres en entrée :
+- `inputs/stored_data` : Il s’agit ici d’une liste (présence des caractères « `[ ]` ») qui prend comme valeur au moins un identifiant entrepôt de **`stored_data`** de type `VECTOR-DB` (voir étape précédente)
+- `output/stored_data/name` : Le nom défini ici est un nommage libre.
 
-        **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** 
+    **Cette information n’est lisible que par un autre utilisateur membre de cet entrepôt, pas par l’utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour vous - producteur de donnée.**
 
-        Cette information est modifiable après coup.
+    Cette information est modifiable après coup.
+- `output/stored_data/storage_tags` : Il s’agit ici d’une liste (présence des caractères « `[ ]` ») qui prend comme valeur au moins un tag associé au stockage qui va accueillir la donnée de sortie.
 
-    - **_output/stored_data/storage_tags_** : Il s'agit ici d'une liste (présence des caractères [ ]) qui prend comme valeur au moins un tag associé au stockage qui va accueillir la donnée de sortie. 
+    Vous pouvez retrouver ces tags via la route `GET /datastores/{datastore}/storages` (rubrique Entrepôt du swagger) dans l’attribut de réponse `labels` associé à chaque stockage.
 
-        Vous pouvez retrouvez ces tags via la route GET /datastores/{datastore}/storages (rubrique Entrepôt du Swagger) dans l'attribut de réponse "labels" associé à chaque stockage. 
-
-        Pour une donnée de type tuiles vecteur pré-calculées en sortie, seul le stockage S3 est accessible, ce qui correspond au label, donc au storage_tag "PYRAMIDE".
-    
-    - **_parameters_** : C'est là que toute la configuration du traitement prend corps :
-
-        - **_composition_** : Définit les couches qui vont être tuilées avec pour chaque couche :
-
-            - **_table_** : Le nom technique de la relation à tuiler, tel que défini dans la stored_data
-
-            - **_layer_** : Le nom technique de la relation telle qu'elle sera présentée dans le flux. Paramètre optionnel, utile à définir en cas de renommage.
-
-            - **_filter_** : Critère de filtrage pour ne diffuser que le objets correspondant au critère de filtrage. Utilisez une syntaxe de type PostgreSQL : "filter" : "mon_champ='ma valeur'".
-
-            - **_top_level_** : Niveau haut (le plus dézoomé, le chiffre le plus faible) de la pyramide auquel la couche sera tuilée et donc visible.
-
-            - **_bottom_level_** : Niveau bas (le plus zoomé, le chiffre le plus grand) de la pyramide auquel la couche sera tuilée et donc visible.
-
-            - **_attributes_** : Liste des attributs, entre doubles quotes et séparés par des virgules à diffuser dans le flux. Pour diffuser tous les attributs, déclarez le caractère * .
-        
-        - **_bottom_level_** : Niveau haut (le plus dézoomé, le chiffre le plus faible) de la pyramide auquel la couche sera tuilée et donc visible. Permet de définir un niveau global à l'ensemble de la pyramide.
+    Pour une donnée de type tuiles vecteur pré-calculées en sortie, seul le stockage S3 est accessible, ce qui correspond au label, donc au `storage_tag` : `PYRAMIDE`.
+- `parameters` : C’est là que toute la configuration du traitement prend corps :
+    - `composition` : Définit les couches qui vont être tuilées avec pour chaque couche :
+        - `table` : Le nom technique de la relation à tuiler, tel que défini dans la `stored_data`.
+        - `layer` : Le nom technique de la relation telle qu’elle sera présentée dans le flux. Paramètre optionnel, utile à définir en cas de renommage.
+        - `filter` : Critère de filtrage pour ne diffuser que le objets correspondant au critère de filtrage. Utilisez une syntaxe de type PostgreSQL : `"filter": "mon_champ='ma valeur'"`.
+        - `top_level` : Niveau haut (le plus dézoomé, le chiffre le plus faible) de la pyramide auquel la couche sera tuilée et donc visible.
+        - `bottom_level` : Niveau bas (le plus zoomé, le chiffre le plus grand) de la pyramide auquel la couche sera tuilée et donc visible.
+        - `attributes` : Liste des attributs, entre doubles quotes et séparés par des virgules à diffuser dans le flux. Pour diffuser tous les attributs, déclarez le caractère « `*` » .
+    - `top_level` : Niveau haut (le plus dézoomé, le chiffre le plus faible) de la pyramide auquel la couche sera tuilée et donc visible. Permet de définir un niveau global à l’ensemble de la pyramide.
         :::warning
-        Ce paramètre est obligatoire s'il n'est pas défini pour chaque table dans la composition.
+        Ce paramètre est obligatoire s’il n’est pas défini pour chaque table dans la composition.
 
-        S'il est précisé en plus de la composition, il est préférable d'adopter une valeur cohérente au regarde de celles définies dans la composition : à savoir égale au plus grand bottom_level de la composition.
+        S’il est précisé en plus de la composition, il est préférable d’adopter une valeur cohérente au regard de celles définies dans la composition : à savoir égale au plus grand `top_level` de la composition.
         :::
-
-        - **_top_level_** : Niveau bas (le plus zoomé, le chiffre le plus grand) de la pyramide auquel la couche sera tuilée et donc visible. Permet de définir un niveau global à l'ensemble de la pyramide.
+    - `bottom_level` : Niveau bas (le plus zoomé, le chiffre le plus grand) de la pyramide auquel la couche sera tuilée et donc visible. Permet de définir un niveau global à l’ensemble de la pyramide.
         :::warning
-        Ce paramètre est obligatoire s'il n'est pas défini pour chaque table dans la composition.
+        Ce paramètre est obligatoire s’il n’est pas défini pour chaque table dans la composition.
 
-        S'il est précisé en plus de la composition, il est préférable d'adopter une valeur cohérente au regarde de celles définies dans la composition : à savoir égale au plus petit top_level de la composition.
+        S’il est précisé en plus de la composition, il est préférable d’adopter une valeur cohérente au regard de celles définies dans la composition : à savoir égale au plus petit `bottom_level` de la composition.
         :::
-
-        - **_area_** : WKT de la zone sur laquelle le moissonnage doit se faire, en EPSG:4326. Ce paramètre est obligatoire si la base vecteur en entrée n’a pas d’étendue et est utile si la donnée est disséminée à travers le globe (France + DOM par exemple)
-
-        - **_tippecanoe_options_** : Plus d'informations sur ces options et leur syntaxe peuvent être trouvées sur la [documentation de l'outil](https://github.com/mapbox/tippecanoe/blob/master/README.md).
-
-
+    - `area` : WKT de la zone sur laquelle le moissonnage doit se faire, en EPSG:4326. Ce paramètre est obligatoire si la base vecteur en entrée n’a pas d’étendue et est utile si la donnée est disséminée à travers le globe (France + DOM par exemple).
+    - `tippecanoe_options` : Plus d’informations sur ces options et leur syntaxe peuvent être trouvées sur la [documentation de l’outil](https://github.com/mapbox/tippecanoe/blob/master/README.md).
         ::: info
+        La caractéristique à retenir d’une tuile vectorielle générée avec Tippecanoe est qu’elle ne peut contenir plus de 5 000 objets, et ce quelle que soit la tuile ou son niveau.
 
-        La caractéristique à retenir d'une tuile vectorielle générée avec tippecanoe est qu'elle ne peut contenir plus de 5000 objet, ce quelle que soit la tuile ou son niveau. 
-        
-        C'est la première cause d'échec de traitement par les utilisateurs
-        
-        Les options sont donc essentielles pour adapter le jeu de donnée en entrée à cette contrainte. Elles proposent différentes méthodes de généralisation à petite échelle pour assurer une représentation fiable de la donnée tout en limitant le nombre d'objets par tuile.
+        C’est la première cause d’échec de traitement par les utilisateurs
 
+        Les options sont donc essentielles pour adapter le jeu de donnée en entrée à cette contrainte. Elles proposent différentes méthodes de généralisation à petite échelle pour assurer une représentation fiable de la donnée tout en limitant le nombre d’objets par tuile.
         :::
+
 Vous êtes invités à vous référer au swagger pour avoir les détails et options complètes sur cette partie.
 
 :::info
-Comme pour la livraison il vous est possible de configurer l'envoi d'un mail automatique à la fin du traitement.
+Comme pour la livraison il vous est possible de configurer l’envoi d’un courriel automatique à la fin du traitement.
 
-Pour ce faire, il suffit d'ajouter l'élément json ci-dessous après l'élément "parameters" dans le corps de requête de déclaration d'exécution.
+Pour ce faire, il suffit d’ajouter l’élément JSON ci-dessous après l’élément `parameters` dans le corps de requête de déclaration d’exécution.
 ```json
 "callback": {
     "type": "email",
     "to_address": [
-      "example@mail.fr"
+        "example@mail.fr"
     ]
-  }
-
+}
 ```
 :::
 ???
@@ -302,34 +285,30 @@ Pour ce faire, il suffit d'ajouter l'élément json ci-dessous après l'élémen
 }
 ```
 ???
-??? Plus d'aide sur l'identification de la donnée stockée de sortie
-
-Dès le lancement de l'exécution du traitement, dans le corps de réponse ou à chaque interrogation de la requête d'état d'exécution vous disposez dans le corps de réponse de ces requêtes de l'élément json :
-
+??? Plus d’aide sur l’identification de la donnée stockée de sortie
+Dès le lancement de l’exécution du traitement, dans le corps de réponse ou à chaque interrogation de la requête d’état d’exécution vous disposez dans le corps de réponse de ces requêtes de l’élément JSON :
 ```json
 "output": {
-        "stored_data": {
-            "name": "Pays et éco-régions",
-            "type": "ROK4-PYRAMID-VECTOR",
-            "status": "GENERATING",
-            "_id": "{stored data}"
-        }
+    "stored_data": {
+        "name": "Pays et éco-régions",
+        "type": "ROK4-PYRAMID-VECTOR",
+        "status": "GENERATING",
+        "_id": "{stored data}"
+    }
 }
 ```
-ce qui vous donne l'élément "_id" à isoler pour identifier ensuite votre stored_data de sortie
+Ce qui vous donne l’élément `_id` à isoler pour identifier ensuite votre `stored_data` de sortie.
 
 :::info
-La stored_data de sortie n'est exploitable et interrogeable qu'une fois l'exécution du traitement terminée avec succès.
+La `stored_data` de sortie n’est exploitable et interrogeable qu’une fois l’exécution du traitement terminée avec succès.
 :::
-
-
 ???
 ????
 <br>
 
 ### Diffusion des tuiles vectorielles
 
-Les données de la pyramide de tuiles vectorielles sont diffusables selon l’API Tile Map Service. Cette API est disponible sur un point d’accès de type WMTS-TMS.
+Les données de la pyramide de tuiles vectorielles sont diffusables selon l’API Tile Map Service. Cette API est disponible sur un point d’accès de type `WMTS-TMS`.
 
 #### Création de la configuration
 
@@ -373,17 +352,14 @@ La donnée n’est pas représentée côté serveur, il n’y a donc pas de fich
 {{ "public/data/tutoriels/alimentation-diffusion-simple/globales/production/endpoints.json" | readFILE | safe }}
 ```
 ???
-??? Plus d'aide sur le choix de son point de diffusion
+??? Plus d’aide sur le choix de son point de diffusion
+Cette étape est l’étape clé pour décider si le flux que vous vous apprêtez à publier va être publié en <span lang="en">_open data_</span> ou au contraire seulement aux utilisateurs accrédités. Dans l’écosystème Géoplateforme on appelle ce dernier mode, le mode privé.
 
-Cette étape est l'étape clé pour décider si le flux que vous vous apprêtez à publier va être publié en opendata ou au contraire seulement aux utilisateurs accrédités. Dans l'écosystème Géoplateforme on appelle ce dernier mode, le mode privé.
+Si vous souhaitez publier en <span lang="en">_open data_</span>, vous allez chercher, dans la réponse ci-dessus, un <span lang="en">_endpoint_</span> du type de la configuration créée (pour le tutoriel, `WMTS-TMS`) dont l’**élément `open` est à `true`**.
 
-Si vous souhaitez publier en opendata, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à true**.
+Si vous souhaitez publier en mode **privé**, vous allez chercher, dans la réponse ci-dessus, un <span lang="en">_endpoint_</span> du type de la configuration créée (pour le tutoriel, `WMTS-TMS`) dont l’**élément `open` est à `false`**.
 
-Si vous souhaitez publier en mode **privé**, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à false**.
-
-Le tutoriel est déroulé en mode opendata. Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
-
-
+Le tutoriel est déroulé en mode <span lang="en">_open data_</span>. Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](../../../controle-des-acces/service-de-diffusion/).
 ???
 ????
 <br>
@@ -402,20 +378,17 @@ Le tutoriel est déroulé en mode opendata. Pour accéder à une donnée publié
 }
 ```
 ???
-??? Plus d'aide sur la configuration de la publication
+??? Plus d’aide sur la configuration de la publication
+L’exemple ci-dessus présente une publication en mode <span lang="en">_open data_</span>.
 
-L'exemple ci-dessus présente une publication en mode opendata.
-
-Si vous choisissez de publier en mode privé, le corps de requête sera : 
-
+Si vous choisissez de publier en mode privé, le corps de requête sera : 
 ```json
 {
     "endpoint": "{{ ids.endpoints.private.wmts }}",
     "open": false
 }
 ```
-Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
-
+Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](../../../controle-des-acces/service-de-diffusion/).
 ???
 ????
 <br>

--- a/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/tuilage.md
+++ b/content/fr/guides-developpeur/tutoriels/gestion-des-donnees-vecteur/alimentation-diffusion-vecteur/tuilage.md
@@ -152,7 +152,7 @@ Dans notre exemple ici, on choisit un cas simple : les pays sont présents dans
     "output": {
         "stored_data": {
             "name": "Pays et éco-régions",
-            "storage_tags": ["VECTEUR"]
+            "storage_tags": ["PYARAMIDE"]
         }
     },
     "parameters": {
@@ -173,6 +173,82 @@ Dans notre exemple ici, on choisit un cas simple : les pays sont présents dans
     }
 }
 ```
+???
+??? Plus d'aide sur la configuration d'une exécution de traitement de création d'une pyramide de tuiles vectorielles.
+- Description des paramètres en entrée :
+    - **_inputs/stored_data_** :  Il s'agit ici d'une liste (présence des caractères [ ]) qui prend comme valeur au moins un identifiant entrepôt de **stored_data** de type VECTOR-DB (voir étape précédente)
+    - **_output/stored_data/name_** : Le nom définit ici est un nommage libre.
+
+        **Cette information n'est lisible que par un autre utilisateur membre de cet entrepôt, pas par l'utilisateur final. Vous êtes donc invité à renseigner ici des informations parlantes pour  vous - producteur de donnée.** 
+
+        Cette information est modifiable après coup.
+
+    - **_output/stored_data/storage_tags_** : Il s'agit ici d'une liste (présence des caractères [ ]) qui prend comme valeur au moins un tag associé au stockage qui va accueillir la donnée de sortie. 
+
+        Vous pouvez retrouvez ces tags via la route GET /datastores/{datastore}/storages (rubrique Entrepôt du Swagger) dans l'attribut de réponse "labels" associé à chaque stockage. 
+
+        Pour une donnée de type tuiles vecteur pré-calculées en sortie, seul le stockage S3 est accessible, ce qui correspond au label, donc au storage_tag "PYRAMIDE".
+    
+    - **_parameters_** : C'est là que toute la configuration du traitement prend corps :
+
+        - **_composition_** : Définit les couches qui vont être tuilées avec pour chaque couche :
+
+            - **_table_** : Le nom technique de la relation à tuiler, tel que défini dans la stored_data
+
+            - **_layer_** : Le nom technique de la relation telle qu'elle sera présentée dans le flux. Paramètre optionnel, utile à définir en cas de renommage.
+
+            - **_filter_** : Critère de filtrage pour ne diffuser que le objets correspondant au critère de filtrage. Utilisez une syntaxe de type PostgreSQL : "filter" : "mon_champ='ma valeur'".
+
+            - **_top_level_** : Niveau haut (le plus dézoomé, le chiffre le plus faible) de la pyramide auquel la couche sera tuilée et donc visible.
+
+            - **_bottom_level_** : Niveau bas (le plus zoomé, le chiffre le plus grand) de la pyramide auquel la couche sera tuilée et donc visible.
+
+            - **_attributes_** : Liste des attributs, entre doubles quotes et séparés par des virgules à diffuser dans le flux. Pour diffuser tous les attributs, déclarez le caractère * .
+        
+        - **_bottom_level_** : Niveau haut (le plus dézoomé, le chiffre le plus faible) de la pyramide auquel la couche sera tuilée et donc visible. Permet de définir un niveau global à l'ensemble de la pyramide.
+        :::warning
+        Ce paramètre est obligatoire s'il n'est pas défini pour chaque table dans la composition.
+
+        S'il est précisé en plus de la composition, il est préférable d'adopter une valeur cohérente au regarde de celles définies dans la composition : à savoir égale au plus grand bottom_level de la composition.
+        :::
+
+        - **_top_level_** : Niveau bas (le plus zoomé, le chiffre le plus grand) de la pyramide auquel la couche sera tuilée et donc visible. Permet de définir un niveau global à l'ensemble de la pyramide.
+        :::warning
+        Ce paramètre est obligatoire s'il n'est pas défini pour chaque table dans la composition.
+
+        S'il est précisé en plus de la composition, il est préférable d'adopter une valeur cohérente au regarde de celles définies dans la composition : à savoir égale au plus petit top_level de la composition.
+        :::
+
+        - **_area_** : WKT de la zone sur laquelle le moissonnage doit se faire, en EPSG:4326. Ce paramètre est obligatoire si la base vecteur en entrée n’a pas d’étendue et est utile si la donnée est disséminée à travers le globe (France + DOM par exemple)
+
+        - **_tippecanoe_options_** : Plus d'informations sur ces options et leur syntaxe peuvent être trouvées sur la [documentation de l'outil](https://github.com/mapbox/tippecanoe/blob/master/README.md).
+
+
+        ::: info
+
+        La caractéristique à retenir d'une tuile vectorielle générée avec tippecanoe est qu'elle ne peut contenir plus de 5000 objet, ce quelle que soit la tuile ou son niveau. 
+        
+        C'est la première cause d'échec de traitement par les utilisateurs
+        
+        Les options sont donc essentielles pour adapter le jeu de donnée en entrée à cette contrainte. Elles proposent différentes méthodes de généralisation à petite échelle pour assurer une représentation fiable de la donnée tout en limitant le nombre d'objets par tuile.
+
+        :::
+Vous êtes invités à vous référer au swagger pour avoir les détails et options complètes sur cette partie.
+
+:::info
+Comme pour la livraison il vous est possible de configurer l'envoi d'un mail automatique à la fin du traitement.
+
+Pour ce faire, il suffit d'ajouter l'élément json ci-dessous après l'élément "parameters" dans le corps de requête de déclaration d'exécution.
+```json
+"callback": {
+    "type": "email",
+    "to_address": [
+      "example@mail.fr"
+    ]
+  }
+
+```
+:::
 ???
 ????
 <br>
@@ -226,6 +302,28 @@ Dans notre exemple ici, on choisit un cas simple : les pays sont présents dans
 }
 ```
 ???
+??? Plus d'aide sur l'identification de la donnée stockée de sortie
+
+Dès le lancement de l'exécution du traitement, dans le corps de réponse ou à chaque interrogation de la requête d'état d'exécution vous disposez dans le corps de réponse de ces requêtes de l'élément json :
+
+```json
+"output": {
+        "stored_data": {
+            "name": "Pays et éco-régions",
+            "type": "ROK4-PYRAMID-VECTOR",
+            "status": "GENERATING",
+            "_id": "{stored data}"
+        }
+}
+```
+ce qui vous donne l'élément "_id" à isoler pour identifier ensuite votre stored_data de sortie
+
+:::info
+La stored_data de sortie n'est exploitable et interrogeable qu'une fois l'exécution du traitement terminée avec succès.
+:::
+
+
+???
 ????
 <br>
 
@@ -275,6 +373,18 @@ La donnée n’est pas représentée côté serveur, il n’y a donc pas de fich
 {{ "public/data/tutoriels/alimentation-diffusion-simple/globales/production/endpoints.json" | readFILE | safe }}
 ```
 ???
+??? Plus d'aide sur le choix de son point de diffusion
+
+Cette étape est l'étape clé pour décider si le flux que vous vous apprêtez à publier va être publié en opendata ou au contraire seulement aux utilisateurs accrédités. Dans l'écosystème Géoplateforme on appelle ce dernier mode, le mode privé.
+
+Si vous souhaitez publier en opendata, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à true**.
+
+Si vous souhaitez publier en mode **privé**, vous allez chercher, dans la réponse si dessus, un endpoint du type de la configuration créée (pour le tutoriel, WFS) dont l'**élément "open" est à false**.
+
+Le tutoriel est déroulé en mode opendata. Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
+
+
+???
 ????
 <br>
 
@@ -291,6 +401,21 @@ La donnée n’est pas représentée côté serveur, il n’y a donc pas de fich
     "open": true
 }
 ```
+???
+??? Plus d'aide sur la configuration de la publication
+
+L'exemple ci-dessus présente une publication en mode opendata.
+
+Si vous choisissez de publier en mode privé, le corps de requête sera : 
+
+```json
+{
+    "endpoint": "{{ ids.endpoints.private.wmts }}",
+    "open": false
+}
+```
+Pour accéder à une donnée publiée en privé, référez vous au [tutoriel sur le contrôle des accès](https://cartes.gouv.fr/aide/fr/guides-developpeur/tutoriels/controle-des-acces/service-de-diffusion/)
+
 ???
 ????
 <br>


### PR DESCRIPTION
Ajout des compléments sur le turo alim-diff vecteur selon la méthode vue avec Skander : à savoir un accordéon "plus d'info" replié pour ne pas alourdir la lecture du coeur du tuto.

Si ok je complète le reste ua fil de l'eau et du temps