### PR TITLE
feat: fond gris sur les éléments <code> inline

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -31,6 +31,13 @@ code {
     overflow-wrap: break-word;
 }
 
+:not(pre) > code {
+    background-color: var(--background-contrast-grey);
+    border-radius: 0.25rem;
+    padding: 0.1em 0.35em;
+    font-size: 0.9em;
+}
+
 pre[class*="language-"] {
     margin-bottom: 1.5em !important;
 }


### PR DESCRIPTION
Proposition de style sur les éléments `<code>` inline, ajout d'un background gris pour une meilleure lisibilité.

Comparatif :

<img width="1047" height="462" alt="Capture d’écran 2026-08-14 170503" src="https://github.com/user-attachments/assets/74ec9fe9-942c-4e1f-998e-b749ed86a48a" />
<img width="1052" height="512" alt="Capture d’écran 2026-08-14 170424" src="https://github.com/user-attachments/assets/54467c1a-c065-468e-9ddb-8faafc6f4be6" />
